### PR TITLE
Fix test runner module path

### DIFF
--- a/unit_test/features/run_all_test.py
+++ b/unit_test/features/run_all_test.py
@@ -1,23 +1,37 @@
-"""Utility script to run all unit tests in the :mod:`unit_test.features` directory.
+"""Run all unit tests under :mod:`unit_test.features`.
 
-The script is kept at the repository root so that developers can easily run all
-tests without invoking ``pytest`` directly. It discovers any files matching
-``test_*.py`` recursively under ``unit_test.features`` and executes them using the standard
-``unittest`` test runner.
+This script ensures that the repository root is prioritised on ``sys.path`` so
+that tests import the local :mod:`pyblinker` package rather than similarly
+named modules inside the test tree.
 """
 
+from __future__ import annotations
+
+import logging
 import sys
 import unittest
 from pathlib import Path
 
+logger = logging.getLogger(__name__)
 
-if __name__ == "__main__":
-    base_dir = Path(__file__).resolve().parent
+ROOT = Path(__file__).resolve().parent
+REPO_ROOT = ROOT.parent.parent
+sys.path.insert(0, str(REPO_ROOT))
 
-    # Ensure the project root (one level above ``unit_test.features``) is on ``sys.path``
-    sys.path.insert(0, str(base_dir.parent))
 
+def main() -> None:
+    """Discover and execute the feature unit tests."""
+    logger.info("Discovering feature tests in %s", ROOT)
     loader = unittest.TestLoader()
-    suite = loader.discover(start_dir=str(base_dir), pattern="test_*.py")
+    suite = loader.discover(
+        start_dir=str(ROOT),
+        pattern="test_*.py",
+        top_level_dir=str(REPO_ROOT),
+    )
+    logger.info("Running feature test suite")
     runner = unittest.TextTestRunner(verbosity=2)
     runner.run(suite)
+
+
+if __name__ == "__main__":
+    main()

--- a/unit_test/run_all_features_test.py
+++ b/unit_test/run_all_features_test.py
@@ -22,7 +22,11 @@ def main() -> None:
     download_test_files()
     multiprocessing.set_start_method("spawn", force=True)
     loader = unittest.TestLoader()
-    suite = loader.discover(str(FEATURE_DIR), pattern="test_*.py")
+    suite = loader.discover(
+        start_dir=str(FEATURE_DIR),
+        pattern="test_*.py",
+        top_level_dir=str(ROOT.parent),
+    )
     runner = unittest.TextTestRunner(verbosity=2)
     runner.run(suite)
 

--- a/unit_test/run_all_migration_test.py
+++ b/unit_test/run_all_migration_test.py
@@ -22,7 +22,11 @@ def main() -> None:
     download_test_files()
     multiprocessing.set_start_method("spawn", force=True)
     loader = unittest.TestLoader()
-    suite = loader.discover(str(MIGRATION_DIR), pattern="test_*.py")
+    suite = loader.discover(
+        start_dir=str(MIGRATION_DIR),
+        pattern="test_*.py",
+        top_level_dir=str(ROOT.parent),
+    )
     runner = unittest.TextTestRunner(verbosity=2)
     runner.run(suite)
 


### PR DESCRIPTION
## Summary
- ensure repository package has priority during migration tests discovery
- guarantee feature tests load project modules rather than similarly-named test packages
- fix feature test script to add repo root and top-level directory so tests import `pyblinker`

## Testing
- `python unit_test/run_all_migration_test.py` *(fails: KeyboardInterrupt after partial 1.65GB dataset download)*
- `python unit_test/run_all_features_test.py`
- `python unit_test/features/run_all_test.py` *(fails: FileNotFoundError: ear_eog_raw.fif)*


------
https://chatgpt.com/codex/tasks/task_e_68a721b7bdc08325abf63c247fc3b10c