### PR TITLE
Add frequency-domain test for averaged EAR channel

### DIFF
--- a/unit_test/features/frequency_domain/test_frequency_domain_blink_features.py
+++ b/unit_test/features/frequency_domain/test_frequency_domain_blink_features.py
@@ -83,6 +83,10 @@ class TestBlinkFrequencyFeatures(unittest.TestCase):
         """Run aggregation on EOG channel."""
         self._run_channel("EOG-EEG-eog_vert_left")
 
+    def test_ear_avg_ear(self) -> None:
+        """Run aggregation on averaged EAR channel."""
+        self._run_channel("EAR-avg_ear")
+
 
 if __name__ == "__main__":
     logging.basicConfig(level=logging.INFO)


### PR DESCRIPTION
## Summary
- test frequency-domain blink metrics on averaged EAR channel

## Testing
- `pytest unit_test/features/frequency_domain/test_frequency_domain_blink_features.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa8e90bb748325a65c2b7ff7ebed26