### PR TITLE
refactor: replace synthetic blink generation with real epochs

### DIFF
--- a/unit_test/blink_features/energy/test_energy_complexity_features_aggregate.py
+++ b/unit_test/blink_features/energy/test_energy_complexity_features_aggregate.py
@@ -1,0 +1,94 @@
+"""Aggregate energy feature tests for real EAR data."""
+import logging
+import math
+import unittest
+from pathlib import Path
+
+import mne
+
+from pyblinker.blink_features.energy.aggregate import (
+    aggregate_energy_complexity_features,
+)
+from pyblinker.utils import slice_raw_into_mne_epochs
+
+logger = logging.getLogger(__name__)
+
+PROJECT_ROOT = Path(__file__).resolve().parents[3]
+
+
+class TestEnergyComplexityFeaturesAggregate(unittest.TestCase):
+    """Validate aggregated energy metrics across epochs."""
+
+    def setUp(self) -> None:
+        raw_path = (
+            PROJECT_ROOT
+            / "unit_test"
+            / "test_files"
+            / "ear_eog_raw.fif"
+        )
+        raw = mne.io.read_raw_fif(raw_path, preload=True, verbose=False)
+        self.sfreq = raw.info["sfreq"]
+        self.epochs = (
+            slice_raw_into_mne_epochs(
+                raw, epoch_len=30.0, blink_label=None, progress_bar=False
+            )
+            .copy()
+            .pick("EAR-avg_ear")
+        )
+        self.n_epochs = len(self.epochs)
+
+    def _collect_blinks(self) -> tuple[list[dict], int]:
+        """Convert epoch metadata to blink dicts.
+
+        Returns
+        -------
+        tuple[list[dict], int]
+            Blink annotations and an example empty epoch index.
+        """
+        blinks: list[dict] = []
+        data = self.epochs.get_data(picks=[0]).squeeze()
+        empty_epoch = None
+        durations = self.epochs.metadata["blink_duration"]
+        for idx, onset in enumerate(self.epochs.metadata["blink_onset"]):
+            signal = data[idx]
+            duration = durations[idx]
+            if onset is None:
+                if empty_epoch is None:
+                    empty_epoch = idx
+                continue
+            onset_list = onset if isinstance(onset, list) else [onset]
+            duration_list = duration if isinstance(duration, list) else [duration]
+            for o, d in zip(onset_list, duration_list):
+                start = int(float(o) * self.sfreq)
+                end = int((float(o) + float(d)) * self.sfreq)
+                blinks.append(
+                    {
+                        "epoch_index": idx,
+                        "epoch_signal": signal,
+                        "refined_start_frame": start,
+                        "refined_end_frame": end,
+                    }
+                )
+        if empty_epoch is None:
+            empty_epoch = 0
+        return blinks, empty_epoch
+
+    def test_aggregate_energy_features(self) -> None:
+        """Aggregate per-epoch energy metrics and verify output."""
+        blinks, empty_epoch = self._collect_blinks()
+        df = aggregate_energy_complexity_features(
+            blinks, self.sfreq, self.n_epochs
+        )
+        logger.debug("Aggregated energy DataFrame: %s", df.to_dict("index"))
+        self.assertEqual(df.shape, (self.n_epochs, 12))
+        self.assertTrue(math.isnan(df.loc[empty_epoch, "blink_signal_energy_mean"]))
+        if blinks:
+            idx = blinks[0]["epoch_index"]
+            feats = df.loc[idx]
+            self.assertGreater(feats["blink_signal_energy_mean"], 0.0)
+            self.assertGreater(feats["blink_line_length_mean"], 0.0)
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    unittest.main()

--- a/unit_test/blink_features/energy/test_energy_features.py
+++ b/unit_test/blink_features/energy/test_energy_features.py
@@ -2,10 +2,9 @@
 Blink feature extraction tests.
 
 This module contains unit tests for per-blink feature computation using
-``mne.Epochs`` derived from the real ``ear_eog_raw.fif`` recording as well as
-directly cropped ``mne.io.Raw`` segments. Testing on both epoch-based and
-cropped raw data ensures the feature functions operate consistently regardless
-of how blink annotations are generated.
+``mne.Epochs`` derived from the real ``ear_eog_raw.fif`` recording. Using
+recorded data ensures the feature functions operate consistently on realistic
+blink annotations.
 
 The tested feature set includes:
 
@@ -28,10 +27,11 @@ amplitude-driven ones.  Complexity metrics (entropy, fractal dimension, etc.)
 may be added later but are not yet stable at 30 Hz per-blink sampling.
 """
 
-import unittest
-import math
 import logging
+import math
 from pathlib import Path
+import unittest
+
 import mne
 
 from pyblinker.blink_features.energy.energy_complexity_features import (
@@ -59,33 +59,43 @@ class TestEnergyComplexityFeatures(unittest.TestCase):
         self.sfreq = raw.info["sfreq"]
         self.epochs = slice_raw_into_mne_epochs(
             raw, epoch_len=30.0, blink_label=None, progress_bar=False
+        ).copy().pick("EAR-avg_ear")
+
+    def _blinks_from_epoch(self, epoch_index: int) -> list[dict]:
+        """Extract blink dictionaries from a single epoch."""
+        epoch = self.epochs[epoch_index]
+        signal = epoch.get_data().squeeze()
+        meta = epoch.metadata.iloc[0]
+        onsets = meta["blink_onset"]
+        durations = meta["blink_duration"]
+        onsets = (
+            onsets
+            if isinstance(onsets, list)
+            else ([] if onsets is None else [onsets])
         )
-        epochs = self.epochs.copy().pick("EAR-avg_ear")
-        data = epochs.get_data().squeeze()
-        self.per_epoch = [[] for _ in range(len(epochs))]
-        for idx, (onset, duration) in enumerate(
-            zip(epochs.metadata["blink_onset"], epochs.metadata["blink_duration"])
-        ):
-            signal = data[idx]
-            if onset is None:
-                continue
-            onset_list = onset if isinstance(onset, list) else [onset]
-            duration_list = duration if isinstance(duration, list) else [duration]
-            for o, d in zip(onset_list, duration_list):
-                start = int(float(o) * self.sfreq)
-                end = int((float(o) + float(d)) * self.sfreq)
-                self.per_epoch[idx].append(
-                    {
-                        "epoch_index": idx,
-                        "epoch_signal": signal,
-                        "refined_start_frame": start,
-                        "refined_end_frame": end,
-                    }
-                )
+        durations = (
+            durations
+            if isinstance(durations, list)
+            else ([] if durations is None else [durations])
+        )
+        blinks: list[dict] = []
+        for o, d in zip(onsets, durations):
+            start = int(float(o) * self.sfreq)
+            end = int((float(o) + float(d)) * self.sfreq)
+            blinks.append(
+                {
+                    "epoch_index": epoch_index,
+                    "epoch_signal": signal,
+                    "refined_start_frame": start,
+                    "refined_end_frame": end,
+                }
+            )
+        return blinks
 
     def test_first_epoch_features(self) -> None:
         """Verify energy metrics for the first epoch."""
-        feats = compute_energy_complexity_features(self.per_epoch[0], self.sfreq)
+        blinks = self._blinks_from_epoch(0)
+        feats = compute_energy_complexity_features(blinks, self.sfreq)
         logger.debug(f"Energy features epoch 0: {feats}")
         self.assertAlmostEqual(
             feats["blink_signal_energy_mean"], 0.00999, places=5
@@ -99,44 +109,11 @@ class TestEnergyComplexityFeatures(unittest.TestCase):
 
     def test_nan_with_no_blinks(self) -> None:
         """Epoch without blinks should yield NaN for energy mean."""
-        feats = compute_energy_complexity_features(self.per_epoch[2], self.sfreq)
+        blinks = self._blinks_from_epoch(2)
+        feats = compute_energy_complexity_features(blinks, self.sfreq)
         logger.debug(f"Energy features epoch 2: {feats}")
         self.assertTrue(math.isnan(feats["blink_signal_energy_mean"]))
         self.assertTrue(math.isnan(feats["blink_line_length_mean"]))
-
-
-class TestEnergyComplexityRealRaw(unittest.TestCase):
-    """Validate energy metrics using a real 30s raw segment."""
-
-    def setUp(self) -> None:
-        raw_path = PROJECT_ROOT / "unit_test" / "test_files" / "ear_eog_raw.fif"
-        raw = mne.io.read_raw_fif(raw_path, preload=True, verbose=False)
-        self.sfreq = raw.info["sfreq"]
-        start, stop = 0.0, 30.0
-        self.signal = raw.get_data(picks="EAR-avg_ear", start=int(start * self.sfreq), stop=int(stop * self.sfreq))[0]
-        self.blinks = []
-        for onset, dur in zip(raw.annotations.onset, raw.annotations.duration):
-            if onset >= start and onset + dur <= stop:
-                s = int((onset - start) * self.sfreq)
-                e = int((onset + dur - start) * self.sfreq)
-                peak = (s + e) // 2
-                self.blinks.append(
-                    {
-                        "refined_start_frame": s,
-                        "refined_peak_frame": peak,
-                        "refined_end_frame": e,
-                        "epoch_signal": self.signal,
-                        "epoch_index": 0,
-                    }
-                )
-
-    def test_segment_zero_means(self) -> None:
-        """Compare a few energy metrics against reference values."""
-        feats = compute_energy_complexity_features(self.blinks, self.sfreq)
-        logger.debug("Real raw energy features: %s", feats)
-        self.assertAlmostEqual(feats["blink_signal_energy_mean"], 0.00999, places=5)
-        self.assertAlmostEqual(feats["blink_line_length_mean"], 0.31655, places=5)
-        self.assertAlmostEqual(feats["blink_velocity_integral_mean"], 0.30872, places=5)
 
 
 if __name__ == "__main__":

--- a/unit_test/blink_features/energy/test_energy_features.py
+++ b/unit_test/blink_features/energy/test_energy_features.py
@@ -1,11 +1,11 @@
 """
 Blink feature extraction tests.
 
-This module contains unit tests for per-blink feature computation, using both
-synthetic :class:`mne.Epochs` data and real ``mne.io.Raw`` segments loaded
-from ``ear_eog_raw.fif``.  Testing on both fabricated epochs and cropped raw
-segments is important for debugging, since the feature functions must work
-consistently regardless of how blink annotations are generated.
+This module contains unit tests for per-blink feature computation using
+``mne.Epochs`` derived from the real ``ear_eog_raw.fif`` recording as well as
+directly cropped ``mne.io.Raw`` segments. Testing on both epoch-based and
+cropped raw data ensures the feature functions operate consistently regardless
+of how blink annotations are generated.
 
 The tested feature set includes:
 
@@ -34,8 +34,10 @@ import logging
 from pathlib import Path
 import mne
 
-from pyblinker.blink_features.energy.energy_complexity_features import compute_energy_complexity_features
-from unit_test.blink_features.fixtures.mock_ear_generation import _generate_refined_ear
+from pyblinker.blink_features.energy.energy_complexity_features import (
+    compute_energy_complexity_features,
+)
+from pyblinker.utils import slice_raw_into_mne_epochs
 
 logger = logging.getLogger(__name__)
 
@@ -44,27 +46,61 @@ PROJECT_ROOT = Path(__file__).resolve().parents[3]
 
 
 class TestEnergyComplexityFeatures(unittest.TestCase):
-    """Tests for energy and complexity metric calculations."""
+    """Tests for energy and complexity metric calculations on epochs."""
 
     def setUp(self) -> None:
-        blinks, sfreq, epoch_len, n_epochs = _generate_refined_ear()
-        self.sfreq = sfreq
-        self.per_epoch = [[] for _ in range(n_epochs)]
-        for blink in blinks:
-            self.per_epoch[blink["epoch_index"]].append(blink)
+        raw_path = (
+            PROJECT_ROOT
+            / "unit_test"
+            / "test_files"
+            / "ear_eog_raw.fif"
+        )
+        raw = mne.io.read_raw_fif(raw_path, preload=True, verbose=False)
+        self.sfreq = raw.info["sfreq"]
+        self.epochs = slice_raw_into_mne_epochs(
+            raw, epoch_len=30.0, blink_label=None, progress_bar=False
+        )
+        epochs = self.epochs.copy().pick("EAR-avg_ear")
+        data = epochs.get_data().squeeze()
+        self.per_epoch = [[] for _ in range(len(epochs))]
+        for idx, (onset, duration) in enumerate(
+            zip(epochs.metadata["blink_onset"], epochs.metadata["blink_duration"])
+        ):
+            signal = data[idx]
+            if onset is None:
+                continue
+            onset_list = onset if isinstance(onset, list) else [onset]
+            duration_list = duration if isinstance(duration, list) else [duration]
+            for o, d in zip(onset_list, duration_list):
+                start = int(float(o) * self.sfreq)
+                end = int((float(o) + float(d)) * self.sfreq)
+                self.per_epoch[idx].append(
+                    {
+                        "epoch_index": idx,
+                        "epoch_signal": signal,
+                        "refined_start_frame": start,
+                        "refined_end_frame": end,
+                    }
+                )
 
     def test_first_epoch_features(self) -> None:
         """Verify energy metrics for the first epoch."""
         feats = compute_energy_complexity_features(self.per_epoch[0], self.sfreq)
         logger.debug(f"Energy features epoch 0: {feats}")
-        self.assertTrue(math.isclose(feats["blink_signal_energy_mean"], 0.007137))
-        self.assertTrue(math.isclose(feats["blink_line_length_mean"], 0.38))
-        self.assertTrue(math.isclose(feats["blink_velocity_integral_mean"], 0.19))
+        self.assertAlmostEqual(
+            feats["blink_signal_energy_mean"], 0.00999, places=5
+        )
+        self.assertAlmostEqual(
+            feats["blink_line_length_mean"], 0.31655, places=5
+        )
+        self.assertAlmostEqual(
+            feats["blink_velocity_integral_mean"], 0.30872, places=5
+        )
 
     def test_nan_with_no_blinks(self) -> None:
         """Epoch without blinks should yield NaN for energy mean."""
-        feats = compute_energy_complexity_features(self.per_epoch[3], self.sfreq)
-        logger.debug(f"Energy features epoch 3: {feats}")
+        feats = compute_energy_complexity_features(self.per_epoch[2], self.sfreq)
+        logger.debug(f"Energy features epoch 2: {feats}")
         self.assertTrue(math.isnan(feats["blink_signal_energy_mean"]))
         self.assertTrue(math.isnan(feats["blink_line_length_mean"]))
 


### PR DESCRIPTION
## Summary
- refactor energy feature unit tests to slice real EAR data into epochs
- remove mock EAR blink generation
- adjust assertions for real-data blink metrics

## Testing
- `pytest unit_test/blink_features/energy/test_energy_features.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab20759d948325acd7ef30ae9f4443