### PR TITLE
refactor: replace synthetic blink generation with real epochs

### DIFF
--- a/unit_test/blink_features/energy/test_energy_complexity_features_aggregate.py
+++ b/unit_test/blink_features/energy/test_energy_complexity_features_aggregate.py
@@ -1,0 +1,82 @@
+"""Aggregate energy feature tests for real EAR data."""
+import logging
+import math
+import unittest
+from pathlib import Path
+
+import mne
+
+from pyblinker.blink_features.energy.aggregate import (
+    aggregate_energy_complexity_features,
+)
+from pyblinker.utils import slice_raw_into_mne_epochs
+
+logger = logging.getLogger(__name__)
+
+PROJECT_ROOT = Path(__file__).resolve().parents[3]
+
+
+class TestEnergyComplexityFeaturesAggregate(unittest.TestCase):
+    """Validate aggregated energy metrics across epochs."""
+
+    def setUp(self) -> None:
+        raw_path = (
+            PROJECT_ROOT
+            / "unit_test"
+            / "test_files"
+            / "ear_eog_raw.fif"
+        )
+        raw = mne.io.read_raw_fif(raw_path, preload=True, verbose=False)
+        self.sfreq = raw.info["sfreq"]
+        self.epochs = slice_raw_into_mne_epochs(
+            raw, epoch_len=30.0, blink_label=None, progress_bar=False
+        ).copy().pick("EAR-avg_ear")
+        self.n_epochs = len(self.epochs)
+
+        data = self.epochs.get_data(picks=[0]).squeeze()
+        durations = self.epochs.metadata["blink_duration"]
+        self.blinks = []
+        self.empty_epoch = None
+        for idx, onset in enumerate(self.epochs.metadata["blink_onset"]):
+            signal = data[idx]
+            duration = durations[idx]
+            if onset is None:
+                if self.empty_epoch is None:
+                    self.empty_epoch = idx
+                continue
+            onset_list = onset if isinstance(onset, list) else [onset]
+            duration_list = duration if isinstance(duration, list) else [duration]
+            for o, d in zip(onset_list, duration_list):
+                start = int(float(o) * self.sfreq)
+                end = int((float(o) + float(d)) * self.sfreq)
+                self.blinks.append(
+                    {
+                        "epoch_index": idx,
+                        "epoch_signal": signal,
+                        "refined_start_frame": start,
+                        "refined_end_frame": end,
+                    }
+                )
+        if self.empty_epoch is None:
+            self.empty_epoch = 0
+
+    def test_aggregate_energy_features(self) -> None:
+        """Aggregate per-epoch energy metrics and verify output."""
+        df = aggregate_energy_complexity_features(
+            self.blinks, self.sfreq, self.n_epochs
+        )
+        logger.debug("Aggregated energy DataFrame: %s", df.to_dict("index"))
+        self.assertEqual(df.shape, (self.n_epochs, 12))
+        self.assertTrue(
+            math.isnan(df.loc[self.empty_epoch, "blink_signal_energy_mean"])
+        )
+        if self.blinks:
+            idx = self.blinks[0]["epoch_index"]
+            feats = df.loc[idx]
+            self.assertGreater(feats["blink_signal_energy_mean"], 0.0)
+            self.assertGreater(feats["blink_line_length_mean"], 0.0)
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    unittest.main()

--- a/unit_test/blink_features/energy/test_energy_features.py
+++ b/unit_test/blink_features/energy/test_energy_features.py
@@ -1,11 +1,9 @@
-"""
-Blink feature extraction tests.
+"""Blink feature extraction tests.
 
-This module contains unit tests for per-blink feature computation, using both
-synthetic :class:`mne.Epochs` data and real ``mne.io.Raw`` segments loaded
-from ``ear_eog_raw.fif``.  Testing on both fabricated epochs and cropped raw
-segments is important for debugging, since the feature functions must work
-consistently regardless of how blink annotations are generated.
+This module contains unit tests for per-blink feature computation using
+blink annotations extracted from the real ``ear_eog_raw.fif`` recording.
+Using recorded data ensures the feature functions operate consistently on
+realistic blink annotations.
 
 The tested feature set includes:
 
@@ -28,14 +26,17 @@ amplitude-driven ones.  Complexity metrics (entropy, fractal dimension, etc.)
 may be added later but are not yet stable at 30 Hz per-blink sampling.
 """
 
-import unittest
-import math
 import logging
+import math
 from pathlib import Path
+import unittest
+
 import mne
 
-from pyblinker.blink_features.energy.energy_complexity_features import compute_energy_complexity_features
-from unit_test.blink_features.fixtures.mock_ear_generation import _generate_refined_ear
+from pyblinker.blink_features.energy.energy_complexity_features import (
+    compute_energy_complexity_features,
+)
+from pyblinker.utils import slice_raw_into_mne_epochs
 
 logger = logging.getLogger(__name__)
 
@@ -44,63 +45,71 @@ PROJECT_ROOT = Path(__file__).resolve().parents[3]
 
 
 class TestEnergyComplexityFeatures(unittest.TestCase):
-    """Tests for energy and complexity metric calculations."""
+    """Tests for energy and complexity metric calculations on epochs."""
 
     def setUp(self) -> None:
-        blinks, sfreq, epoch_len, n_epochs = _generate_refined_ear()
-        self.sfreq = sfreq
-        self.per_epoch = [[] for _ in range(n_epochs)]
-        for blink in blinks:
-            self.per_epoch[blink["epoch_index"]].append(blink)
+        raw_path = (
+            PROJECT_ROOT
+            / "unit_test"
+            / "test_files"
+            / "ear_eog_raw.fif"
+        )
+        raw = mne.io.read_raw_fif(raw_path, preload=True, verbose=False)
+        self.sfreq = raw.info["sfreq"]
+        self.epochs = slice_raw_into_mne_epochs(
+            raw, epoch_len=30.0, blink_label=None, progress_bar=False
+        ).copy().pick("EAR-avg_ear")
+        self.n_epochs = len(self.epochs)
+
+        data = self.epochs.get_data(picks=[0]).squeeze()
+        durations = self.epochs.metadata["blink_duration"]
+        self.blinks = []
+        self.empty_epoch = None
+        for idx, onset in enumerate(self.epochs.metadata["blink_onset"]):
+            signal = data[idx]
+            duration = durations[idx]
+            if onset is None:
+                if self.empty_epoch is None:
+                    self.empty_epoch = idx
+                continue
+            onset_list = onset if isinstance(onset, list) else [onset]
+            duration_list = duration if isinstance(duration, list) else [duration]
+            for o, d in zip(onset_list, duration_list):
+                start = int(float(o) * self.sfreq)
+                end = int((float(o) + float(d)) * self.sfreq)
+                self.blinks.append(
+                    {
+                        "epoch_index": idx,
+                        "epoch_signal": signal,
+                        "refined_start_frame": start,
+                        "refined_end_frame": end,
+                    }
+                )
+        if self.empty_epoch is None:
+            self.empty_epoch = 0
 
     def test_first_epoch_features(self) -> None:
         """Verify energy metrics for the first epoch."""
-        feats = compute_energy_complexity_features(self.per_epoch[0], self.sfreq)
-        logger.debug(f"Energy features epoch 0: {feats}")
-        self.assertTrue(math.isclose(feats["blink_signal_energy_mean"], 0.007137))
-        self.assertTrue(math.isclose(feats["blink_line_length_mean"], 0.38))
-        self.assertTrue(math.isclose(feats["blink_velocity_integral_mean"], 0.19))
+        blinks0 = [b for b in self.blinks if b["epoch_index"] == 0]
+        feats = compute_energy_complexity_features(blinks0, self.sfreq)
+        logger.debug("Energy features epoch 0: %s", feats)
+        self.assertAlmostEqual(
+            feats["blink_signal_energy_mean"], 0.0099913, places=5
+        )
+        self.assertAlmostEqual(
+            feats["blink_line_length_mean"], 0.316545, places=5
+        )
+        self.assertAlmostEqual(
+            feats["blink_velocity_integral_mean"], 0.308717, places=5
+        )
 
     def test_nan_with_no_blinks(self) -> None:
         """Epoch without blinks should yield NaN for energy mean."""
-        feats = compute_energy_complexity_features(self.per_epoch[3], self.sfreq)
-        logger.debug(f"Energy features epoch 3: {feats}")
+        blinks = [b for b in self.blinks if b["epoch_index"] == self.empty_epoch]
+        feats = compute_energy_complexity_features(blinks, self.sfreq)
+        logger.debug("Energy features epoch %d: %s", self.empty_epoch, feats)
         self.assertTrue(math.isnan(feats["blink_signal_energy_mean"]))
         self.assertTrue(math.isnan(feats["blink_line_length_mean"]))
-
-
-class TestEnergyComplexityRealRaw(unittest.TestCase):
-    """Validate energy metrics using a real 30s raw segment."""
-
-    def setUp(self) -> None:
-        raw_path = PROJECT_ROOT / "unit_test" / "test_files" / "ear_eog_raw.fif"
-        raw = mne.io.read_raw_fif(raw_path, preload=True, verbose=False)
-        self.sfreq = raw.info["sfreq"]
-        start, stop = 0.0, 30.0
-        self.signal = raw.get_data(picks="EAR-avg_ear", start=int(start * self.sfreq), stop=int(stop * self.sfreq))[0]
-        self.blinks = []
-        for onset, dur in zip(raw.annotations.onset, raw.annotations.duration):
-            if onset >= start and onset + dur <= stop:
-                s = int((onset - start) * self.sfreq)
-                e = int((onset + dur - start) * self.sfreq)
-                peak = (s + e) // 2
-                self.blinks.append(
-                    {
-                        "refined_start_frame": s,
-                        "refined_peak_frame": peak,
-                        "refined_end_frame": e,
-                        "epoch_signal": self.signal,
-                        "epoch_index": 0,
-                    }
-                )
-
-    def test_segment_zero_means(self) -> None:
-        """Compare a few energy metrics against reference values."""
-        feats = compute_energy_complexity_features(self.blinks, self.sfreq)
-        logger.debug("Real raw energy features: %s", feats)
-        self.assertAlmostEqual(feats["blink_signal_energy_mean"], 0.00999, places=5)
-        self.assertAlmostEqual(feats["blink_line_length_mean"], 0.31655, places=5)
-        self.assertAlmostEqual(feats["blink_velocity_integral_mean"], 0.30872, places=5)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- compute energy features directly from epoch metadata, removing raw segment refinement
- aggregate energy-complexity metrics across epochs using metadata-derived blink annotations

## Testing
- `pytest unit_test/blink_features/energy/test_energy_features.py unit_test/blink_features/energy/test_energy_complexity_features_aggregate.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab20759d948325acd7ef30ae9f4443