### PR TITLE
Refactor blink event features to use epoch metadata

### DIFF
--- a/pyblinker/blink_features/blink_events/event_features/__init__.py
+++ b/pyblinker/blink_features/blink_events/event_features/__init__.py
@@ -1,8 +1,8 @@
 """Blink event feature modules."""
 from .aggregate import aggregate_blink_event_features
-from .blink_count import blink_count_epoch
+from .blink_count import blink_count_epoch, blink_count
 from .blink_rate import blink_rate_epoch
-from .inter_blink_interval import compute_ibi_features
+from .inter_blink_interval import compute_ibi_features, inter_blink_interval_epochs
 from .blink_interval_distribution import (
     blink_interval_distribution_segment,
     aggregate_blink_interval_distribution,
@@ -12,8 +12,10 @@ from .blink_count_epochs import blink_count_epochs
 __all__ = [
     "aggregate_blink_event_features",
     "blink_count_epoch",
+    "blink_count",
     "blink_rate_epoch",
     "compute_ibi_features",
+    "inter_blink_interval_epochs",
     "blink_interval_distribution_segment",
     "aggregate_blink_interval_distribution",
     "blink_count_epochs",

--- a/pyblinker/blink_features/blink_events/event_features/aggregate.py
+++ b/pyblinker/blink_features/blink_events/event_features/aggregate.py
@@ -1,77 +1,88 @@
-"""Aggregate blink event features."""
-from typing import Dict, Iterable, List, Sequence, Set
+"""Aggregate blink event features using :class:`mne.Epochs` metadata."""
+from __future__ import annotations
+
+from typing import Iterable, Sequence
 
 import logging
+
+import mne
+import numpy as np
 import pandas as pd
 
-from .blink_count import blink_count_epoch
-from .blink_rate import blink_rate_epoch
-from .inter_blink_interval import compute_ibi_features
+from .blink_count import blink_count
+from .inter_blink_interval import inter_blink_interval_epochs
+from .utils import normalize_picks, require_channels
 
 logger = logging.getLogger(__name__)
 
 
 def aggregate_blink_event_features(
-    blinks: Iterable[Dict[str, int]],
-    sfreq: float,
-    epoch_len: float,
-    n_epochs: int,
+    epochs: mne.Epochs,
+    picks: str | Iterable[str],
     features: Sequence[str] | None = None,
 ) -> pd.DataFrame:
-    """Aggregate blink-event based metrics for multiple epochs.
+    """Aggregate blink-event metrics across all epochs.
 
     Parameters
     ----------
-    blinks : Iterable[dict]
-        Iterable of blink annotations containing an ``epoch_index`` field.
-    sfreq : float
-        Sampling frequency of the recording in Hertz.
-    epoch_len : float
-        Length of each epoch in seconds.
-    n_epochs : int
-        Total number of epochs to aggregate.
-
-    features : Sequence[str] | None, optional
-        Iterable of feature groups to compute. Valid options are
-        ``"blink_count"``, ``"blink_rate"`` and ``"ibi"``.  Passing ``None``
+    epochs : mne.Epochs
+        Epoch object with metadata containing ``blink_onset`` and
+        ``blink_duration`` columns.
+    picks : str or iterable of str
+        Channel name(s) used when computing inter-blink interval (IBI)
+        statistics. The same IBI values are used for all channels because
+        blink timing is not channel-specific in the metadata yet.
+    features : sequence of str or None, optional
+        Subset of feature groups to compute. Valid keys are
+        ``"blink_total"``, ``"blink_rate"`` and ``"ibi"``. Passing ``None``
         (default) computes all features.
 
     Returns
     -------
     pandas.DataFrame
-        DataFrame indexed by epoch containing the selected features for
-        each epoch.
+        Single-row DataFrame containing the aggregated metrics.
+
+    Raises
+    ------
+    ValueError
+        If an unknown feature key is requested or if required channels are
+        missing from ``epochs`` when ``"ibi"`` is selected.
     """
-    logger.info("Aggregating blink features over %s epochs", n_epochs)
 
-    valid: Set[str] = {"blink_count", "blink_rate", "ibi"}
-    selected: Set[str]
-    if features is None:
-        selected = valid
-    else:
-        selected = set(features)
-        invalid = selected - valid
-        if invalid:
-            raise ValueError(f"Unknown feature keys: {sorted(invalid)}")
+    logger.info("Aggregating blink features from %d epochs", len(epochs))
 
-    per_epoch: List[List[Dict[str, int]]] = [list() for _ in range(n_epochs)]
-    for blink in blinks:
-        idx = blink["epoch_index"]
-        if 0 <= idx < n_epochs:
-            per_epoch[idx].append(blink)
-    records = []
-    for epoch_idx, epoch_blinks in enumerate(per_epoch):
-        record = {"epoch": epoch_idx}
+    valid = {"blink_total", "blink_rate", "ibi"}
+    selected = set(features) if features is not None else valid
+    invalid = selected - valid
+    if invalid:
+        raise ValueError(f"Unknown feature keys: {sorted(invalid)}")
 
-        if "blink_count" in selected:
-            record["blink_count"] = blink_count_epoch(epoch_blinks)
+    record: dict[str, float] = {}
 
-        if "blink_rate" in selected:
-            record["blink_rate"] = blink_rate_epoch(epoch_blinks, epoch_len)
+    counts_df = blink_count(epochs)
+    if "blink_total" in selected or "blink_rate" in selected:
+        blink_total = float(counts_df["blink_count"].sum())
+    if "blink_total" in selected:
+        record["blink_total"] = blink_total
 
-        if "ibi" in selected:
-            record.update(compute_ibi_features(epoch_blinks, sfreq))
+    if "blink_rate" in selected:
+        epoch_len = epochs.tmax - epochs.tmin + 1.0 / epochs.info["sfreq"]
+        total_duration = epoch_len * len(epochs)
+        record["blink_rate"] = (
+            blink_total / total_duration * 60.0 if total_duration else float("nan")
+        )
 
-        records.append(record)
-    df = pd.DataFrame.from_records(records).set_index("epoch")
+    if "ibi" in selected:
+        picks_list = normalize_picks(picks)
+        require_channels(epochs, picks_list)
+        ibis_df = inter_blink_interval_epochs(epochs, picks_list)
+        for ch in picks_list:
+            record[f"ibi_{ch}"] = float(np.nanmean(ibis_df[f"ibi_{ch}"].to_numpy()))
+
+    df = pd.DataFrame([record])
+    logger.debug("Aggregated feature row: %s", record)
     return df
+
+
+__all__ = ["aggregate_blink_event_features"]
+

--- a/pyblinker/blink_features/blink_events/event_features/inter_blink_interval.py
+++ b/pyblinker/blink_features/blink_events/event_features/inter_blink_interval.py
@@ -1,8 +1,12 @@
 """Inter-blink interval based features."""
-from typing import Dict, List, Sequence
+from typing import Dict, List, Sequence, Iterable
 
 import logging
 import numpy as np
+import pandas as pd
+import mne
+
+from .utils import normalize_picks, require_channels
 
 logger = logging.getLogger(__name__)
 
@@ -139,3 +143,69 @@ def compute_ibi_features(blinks: List[Dict[str, int]], sfreq: float) -> Dict[str
         "ibi_permutation_entropy": pe,
         "ibi_hurst_exponent": hurst,
     }
+
+
+def inter_blink_interval_epochs(
+    epochs: mne.Epochs, picks: str | Iterable[str]
+) -> pd.DataFrame:
+    """Compute mean inter-blink interval per channel for each epoch.
+
+    Parameters
+    ----------
+    epochs : mne.Epochs
+        Epoch object whose metadata contains ``blink_onset`` and
+        ``blink_duration`` columns.
+    picks : str or iterable of str
+        Channel name(s) for which IBI columns are created. The same IBI values
+        are used for all channels because blink timing is not channel-specific
+        in the metadata yet.
+
+    Returns
+    -------
+    pandas.DataFrame
+        DataFrame indexed like ``epochs`` with passthrough metadata columns and
+        one ``ibi_<channel>`` column per requested channel.  Epochs with fewer
+        than two blinks receive ``NaN``.
+
+    Raises
+    ------
+    ValueError
+        If required metadata columns are missing or a requested channel does
+        not exist in ``epochs``.
+
+    Notes
+    -----
+    When multiple blinks occur within an epoch, the mean interval between
+    consecutive blinks is returned. If a single blink or no blink is present,
+    ``NaN`` is assigned.
+    """
+    picks_list = normalize_picks(picks)
+    require_channels(epochs, picks_list)
+    metadata = epochs.metadata
+    if metadata is None or not {"blink_onset", "blink_duration"}.issubset(metadata.columns):
+        raise ValueError("Epochs.metadata must contain 'blink_onset' and 'blink_duration' columns")
+
+    ibis: List[float] = []
+    for onset, duration in zip(metadata["blink_onset"], metadata["blink_duration"]):
+        onsets = (
+            onset
+            if isinstance(onset, list)
+            else ([] if onset is None or pd.isna(onset) else [float(onset)])
+        )
+        durations = (
+            duration
+            if isinstance(duration, list)
+            else ([] if duration is None or pd.isna(duration) else [float(duration)])
+        )
+        if len(onsets) < 2:
+            ibis.append(float("nan"))
+            continue
+        ends = [o + d for o, d in zip(onsets, durations)]
+        intervals = [onsets[i + 1] - ends[i] for i in range(len(onsets) - 1)]
+        ibis.append(float(np.mean(intervals)) if intervals else float("nan"))
+
+    df = metadata[["blink_onset", "blink_duration"]].copy()
+    for ch in picks_list:
+        df[f"ibi_{ch}"] = ibis
+    logger.debug("Computed channel-wise IBI DataFrame shape: %s", df.shape)
+    return df

--- a/pyblinker/blink_features/blink_events/event_features/utils.py
+++ b/pyblinker/blink_features/blink_events/event_features/utils.py
@@ -1,0 +1,49 @@
+"""Utility helpers for blink event features."""
+from __future__ import annotations
+
+import logging
+from typing import Iterable, Sequence, List
+
+import mne
+
+logger = logging.getLogger(__name__)
+
+
+def normalize_picks(picks: str | Iterable[str]) -> List[str]:
+    """Normalize channel picks to a list.
+
+    Parameters
+    ----------
+    picks : str or iterable of str
+        Channel name or collection of channel names.
+
+    Returns
+    -------
+    list of str
+        Normalized list of channel names.
+    """
+    if isinstance(picks, str):
+        return [picks]
+    return list(picks)
+
+
+def require_channels(epochs: mne.Epochs, picks: Sequence[str]) -> None:
+    """Validate that all requested channels exist in the epochs.
+
+    Parameters
+    ----------
+    epochs : mne.Epochs
+        Epochs whose channel names are checked.
+    picks : sequence of str
+        Channel names to validate.
+
+    Raises
+    ------
+    ValueError
+        If any channel in ``picks`` is missing from ``epochs``.
+    """
+    logger.info("Validating channel picks: %s", picks)
+    missing = [p for p in picks if p not in epochs.info["ch_names"]]
+    if missing:
+        raise ValueError(f"Channels not found in epochs: {', '.join(missing)}")
+    logger.debug("All channels present")

--- a/unit_test/blink_features/blink_events/test_aggregate_event_features.py
+++ b/unit_test/blink_features/blink_events/test_aggregate_event_features.py
@@ -1,67 +1,74 @@
-import unittest
-from pyblinker.blink_features.blink_events.event_features import aggregate_blink_event_features
-from unit_test.blink_features.fixtures.mock_ear_generation import _generate_refined_ear
+"""Tests for aggregating blink event features across all epochs."""
+from __future__ import annotations
 
 import unittest
-import math
-import logging
-
-from pyblinker.blink_features.blink_events.event_features.inter_blink_interval import compute_ibi_features
-from unit_test.blink_features.fixtures.mock_ear_generation import _generate_refined_ear
 import logging
 from pathlib import Path
-import unittest
 
 import mne
+import numpy as np
+import pandas as pd
 
-from pyblinker.blink_features.blink_events.event_features.blink_count import (
-    blink_count_epoch,
+from pyblinker.blink_features.blink_events.event_features import (
+    aggregate_blink_event_features,
 )
-from pyblinker.utils import onset_entry_to_blinks, slice_raw_into_mne_epochs
-logger = logging.getLogger(__name__)
-logger = logging.getLogger(__name__)
+from pyblinker.utils import slice_raw_into_mne_epochs
+from unit_test.blink_features.utils.helpers import assert_df_has_columns
 
+logger = logging.getLogger(__name__)
 PROJECT_ROOT = Path(__file__).resolve().parents[3]
+
+
 class TestAggregateBlinkFeatures(unittest.TestCase):
-    """Tests for selecting blink features."""
+    """Validate aggregation of blink features from epochs."""
 
     def setUp(self) -> None:
-        """Load raw data and slice into epochs for blink counting."""
-        logger.info("Setting up epochs for blink count tests...")
         raw_path = (
-                PROJECT_ROOT
-                / "unit_test"
-                / "test_files"
-                / "ear_eog_raw.fif"
+            PROJECT_ROOT
+            / "unit_test"
+            / "test_files"
+            / "ear_eog_raw.fif"
         )
         raw = mne.io.read_raw_fif(raw_path, preload=True, verbose=False)
         self.epochs = slice_raw_into_mne_epochs(
             raw, epoch_len=30.0, blink_label=None, progress_bar=False
         )
-        logger.info("Epoch setup complete.")
-
-        ## for this test, check the ibi for channel "EEG-E8","EOG-EEG-eog_vert_left","EAR-avg_ear"
-    def test_default_features(self) -> None:
-        """By default, all feature columns are returned."""
-        df = aggregate_blink_event_features(
-            self.blinks, self.sfreq, self.epoch_len, self.n_epochs
+        csv_path = (
+            PROJECT_ROOT / "unit_test" / "test_files" / "ear_eog_blink_count_epoch.csv"
         )
-        self.assertIn("blink_count", df.columns)
-        self.assertIn("blink_rate", df.columns)
-        self.assertIn("ibi_mean", df.columns)
+        self.expected_total = pd.read_csv(csv_path)["blink_count"].sum()
+
+    def test_aggregate_all_features(self) -> None:
+        picks = ["EEG-E8", "EOG-EEG-eog_vert_left", "EAR-avg_ear"]
+        df = aggregate_blink_event_features(self.epochs, picks=picks)
+        expected_cols = ["blink_total", "blink_rate"] + [f"ibi_{p}" for p in picks]
+        assert_df_has_columns(self, df, expected_cols)
+        self.assertEqual(len(df), 1)
+
+        self.assertEqual(df.loc[0, "blink_total"], self.expected_total)
+        epoch_len = self.epochs.tmax - self.epochs.tmin + 1.0 / self.epochs.info["sfreq"]
+        total_duration = epoch_len * len(self.epochs)
+        expected_rate = self.expected_total / total_duration * 60.0
+        self.assertAlmostEqual(df.loc[0, "blink_rate"], expected_rate)
+
+        for col in expected_cols:
+            self.assertTrue(np.issubdtype(df[col].dtype, np.number))
+        for ch in picks:
+            self.assertTrue(np.isfinite(df.loc[0, f"ibi_{ch}"]))
+
+    def test_missing_channel(self) -> None:
+        with self.assertRaises(ValueError):
+            aggregate_blink_event_features(self.epochs, picks=["BAD-CHAN"])
 
     def test_select_subset(self) -> None:
-        """Selecting only blink_count should omit other columns."""
         df = aggregate_blink_event_features(
-            self.blinks,
-            self.sfreq,
-            self.epoch_len,
-            self.n_epochs,
-            features=["blink_count"],
+            self.epochs, picks=["EEG-E8"], features=["blink_total"]
         )
-        self.assertEqual(list(df.columns), ["blink_count"])
+        assert_df_has_columns(self, df, ["blink_total"])
+        self.assertEqual(list(df.columns), ["blink_total"])
 
 
 if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
     unittest.main()
 

--- a/unit_test/blink_features/blink_events/test_inter_blink_interval.py
+++ b/unit_test/blink_features/blink_events/test_inter_blink_interval.py
@@ -1,77 +1,81 @@
-"""
-Unit tests for inter-blink interval (IBI) feature extraction.
-
-This module verifies the correctness of IBI feature calculations, particularly
-the mean IBI, under realistic conditions (with and without sufficient blink data).
-"""
+"""Tests for channel-aware inter-blink interval (IBI) features."""
+from __future__ import annotations
 
 import unittest
-import math
-import logging
-
-from pyblinker.blink_features.blink_events.event_features.inter_blink_interval import compute_ibi_features
-from unit_test.blink_features.fixtures.mock_ear_generation import _generate_refined_ear
 import logging
 from pathlib import Path
-import unittest
 
 import mne
+import numpy as np
+import pandas as pd
 
-from pyblinker.blink_features.blink_events.event_features.blink_count import (
-    blink_count_epoch,
+from pyblinker.blink_features.blink_events.event_features.inter_blink_interval import (
+    inter_blink_interval_epochs,
 )
-from pyblinker.utils import onset_entry_to_blinks, slice_raw_into_mne_epochs
-logger = logging.getLogger(__name__)
-logger = logging.getLogger(__name__)
+from pyblinker.blink_features.blink_events.event_features.blink_count import blink_count
+from pyblinker.utils import slice_raw_into_mne_epochs
+from unit_test.blink_features.utils.helpers import assert_df_has_columns
 
+logger = logging.getLogger(__name__)
 PROJECT_ROOT = Path(__file__).resolve().parents[3]
+
+
 class TestInterBlinkInterval(unittest.TestCase):
-    """
-    Tests for `compute_ibi_features`, which calculates metrics on inter-blink intervals
-    given blink timestamps and sampling frequency.
-    """
+    """Validate IBI computation using epoch metadata."""
 
     def setUp(self) -> None:
-        """Load raw data and slice into epochs for blink counting."""
-        logger.info("Setting up epochs for blink count tests...")
         raw_path = (
-                PROJECT_ROOT
-                / "unit_test"
-                / "test_files"
-                / "ear_eog_raw.fif"
+            PROJECT_ROOT
+            / "unit_test"
+            / "test_files"
+            / "ear_eog_raw.fif"
         )
         raw = mne.io.read_raw_fif(raw_path, preload=True, verbose=False)
         self.epochs = slice_raw_into_mne_epochs(
             raw, epoch_len=30.0, blink_label=None, progress_bar=False
         )
-        logger.info("Epoch setup complete.")
 
-        ## for this test, check the ibi for channel "EEG-E8","EOG-EEG-eog_vert_left","EAR-avg_ear"
-    def test_all_ibi_features_first_epoch(self) -> None:
-        """
-        Verify all inter-blink interval (IBI) features for the first epoch against expected values.
-        Ensures correctness for computed statistical metrics and proper handling of undefined ones.
-        """
-        logger.info("Testing all IBI features for the first epoch...")
-        feats = compute_ibi_features(self.per_epoch[0], self.sfreq)
+    def test_channel_ibi(self) -> None:
+        picks = ["EEG-E8", "EOG-EEG-eog_vert_left", "EAR-avg_ear"]
+        df = inter_blink_interval_epochs(self.epochs, picks=picks)
+        expected_cols = ["blink_onset", "blink_duration"] + [f"ibi_{p}" for p in picks]
+        assert_df_has_columns(self, df, expected_cols)
+        self.assertEqual(len(df), len(self.epochs))
 
-        # Exact matches (deterministic blink timing)
-        self.assertTrue(math.isclose(feats["ibi_mean"], 2.9), "Expected mean IBI ~2.9 for first epoch")
-        self.assertTrue(math.isclose(feats["ibi_std"], 0.0), "Expected IBI standard deviation to be 0.0 (no variability)")
-        self.assertTrue(math.isclose(feats["ibi_median"], 2.9), "Expected IBI median to equal 2.9 (same as mean)")
-        self.assertTrue(math.isclose(feats["ibi_min"], 2.9), "Expected IBI minimum to be 2.9 (only value present)")
-        self.assertTrue(math.isclose(feats["ibi_max"], 2.9), "Expected IBI maximum to be 2.9 (only value present)")
-        self.assertTrue(math.isclose(feats["ibi_cv"], 0.0), "Expected IBI coefficient of variation to be 0.0 (no variation)")
-        self.assertTrue(math.isclose(feats["ibi_rmssd"], 0.0), "Expected IBI RMSSD to be 0.0 (no successive differences)")
+        # metadata passthrough
+        pd.testing.assert_series_equal(
+            df["blink_onset"], self.epochs.metadata["blink_onset"], check_names=False
+        )
+        pd.testing.assert_series_equal(
+            df["blink_duration"], self.epochs.metadata["blink_duration"], check_names=False
+        )
 
-        # NaN features (due to insufficient blink count or undefined variability)
-        self.assertTrue(math.isnan(feats["poincare_sd1"]), "Expected NaN for Poincaré SD1 due to zero variability")
-        self.assertTrue(math.isnan(feats["poincare_sd2"]), "Expected NaN for Poincaré SD2 due to zero variability")
-        self.assertTrue(math.isnan(feats["poincare_ratio"]), "Expected NaN for Poincaré ratio (undefined with zero SD2)")
-        self.assertTrue(math.isnan(feats["ibi_permutation_entropy"]), "Expected NaN for permutation entropy (not enough unique values)")
-        self.assertTrue(math.isnan(feats["ibi_hurst_exponent"]), "Expected NaN for Hurst exponent (requires longer time series)")
+        # epoch-wise checks across all epochs using blink counts
+        counts = blink_count(self.epochs)["blink_count"]
+        for idx in range(len(self.epochs)):
+            for p in picks:
+                val = df.loc[idx, f"ibi_{p}"]
+                if counts.loc[idx] >= 2:
+                    self.assertTrue(np.isfinite(val))
+                else:
+                    self.assertTrue(np.isnan(val))
 
+        # explicit checks for first four epochs
+        self.assertTrue(np.isfinite(df.loc[0, "ibi_EEG-E8"]))
+        for idx in [1, 2, 3]:
+            self.assertTrue(np.isnan(df.loc[idx, "ibi_EEG-E8"]))
+        for col in [f"ibi_{p}" for p in picks]:
+            self.assertTrue(np.issubdtype(df[col].dtype, np.number))
 
+    def test_missing_channel(self) -> None:
+        with self.assertRaises(ValueError):
+            inter_blink_interval_epochs(self.epochs, picks=["BAD-CHAN"])
+
+    def test_empty_epochs(self) -> None:
+        empty = self.epochs[:0]
+        df = inter_blink_interval_epochs(empty, picks="EEG-E8")
+        assert_df_has_columns(self, df, ["blink_onset", "blink_duration", "ibi_EEG-E8"])
+        self.assertEqual(len(df), 0)
 
 
 if __name__ == "__main__":

--- a/unit_test/blink_features/utils/helpers.py
+++ b/unit_test/blink_features/utils/helpers.py
@@ -1,0 +1,12 @@
+"""Test utilities for blink feature modules."""
+from __future__ import annotations
+
+from typing import Sequence
+
+import pandas as pd
+
+
+def assert_df_has_columns(testcase, df: pd.DataFrame, columns: Sequence[str]) -> None:
+    """Assert that a DataFrame contains the specified columns."""
+    missing = [c for c in columns if c not in df.columns]
+    testcase.assertFalse(missing, msg=f"Missing columns: {missing}")


### PR DESCRIPTION
## Summary
- add `aggregate_blink_event_features` to compute blink totals, blink rate and channel-aware IBI from epoch metadata
- validate per-epoch blink counts against ground-truth CSV
- expand IBI tests and add aggregation tests for EEG, EOG and EAR channels

## Testing
- `pytest unit_test/blink_features/blink_events/test_blink_count.py unit_test/blink_features/blink_events/test_inter_blink_interval.py unit_test/blink_features/blink_events/test_aggregate_event_features.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68aba60faf988325b8f145399cbf9233