### PR TITLE
feat: add metadata-driven kinematic features

### DIFF
--- a/pyblinker/blink_features/kinematics/__init__.py
+++ b/pyblinker/blink_features/kinematics/__init__.py
@@ -1,6 +1,7 @@
 """Blink kinematic feature package."""
 
 from .aggregate import aggregate_kinematic_features
+from .kinematic_features import compute_kinematic_features
 
-__all__ = ["aggregate_kinematic_features"]
+__all__ = ["aggregate_kinematic_features", "compute_kinematic_features"]
 

--- a/pyblinker/blink_features/kinematics/aggregate.py
+++ b/pyblinker/blink_features/kinematics/aggregate.py
@@ -1,25 +1,43 @@
-"""Aggregate blink kinematic features."""
+"""Aggregate blink kinematic features across epochs."""
+
+from __future__ import annotations
+
 from typing import Any, Dict, Iterable, List
 
 import logging
+import numpy as np
 import pandas as pd
 
-from .kinematic_features import compute_kinematic_features
+from .per_blink import compute_segment_kinematics
+from ..energy.helpers import _safe_stats
 
 logger = logging.getLogger(__name__)
 
+_METRICS = (
+    "peak_amp",
+    "t2p",
+    "vel_mean",
+    "vel_peak",
+    "acc_mean",
+    "acc_peak",
+    "rise_time",
+    "fall_time",
+    "auc",
+    "symmetry",
+)
+_STATS = ("mean", "std", "cv")
+
 
 def aggregate_kinematic_features(
-    blinks: Iterable[Dict[str, Any]],
-    sfreq: float,
-    n_epochs: int,
+    blinks: Iterable[Dict[str, Any]], sfreq: float, n_epochs: int
 ) -> pd.DataFrame:
-    """Aggregate kinematic metrics across epochs.
+    """Aggregate kinematic metrics for each epoch.
 
     Parameters
     ----------
-    blinks : Iterable[dict]
-        Blink annotations with an ``epoch_index`` field.
+    blinks : iterable of dict
+        Blink annotations containing ``epoch_index``, ``refined_start_frame``,
+        ``refined_end_frame`` and ``epoch_signal`` fields.
     sfreq : float
         Sampling frequency in Hertz.
     n_epochs : int
@@ -28,22 +46,37 @@ def aggregate_kinematic_features(
     Returns
     -------
     pandas.DataFrame
-        DataFrame indexed by epoch with kinematic features.
+        DataFrame indexed by epoch with kinematic summary statistics.
     """
+
     logger.info("Aggregating kinematic features over %d epochs", n_epochs)
     per_epoch: List[List[Dict[str, Any]]] = [list() for _ in range(n_epochs)]
     for blink in blinks:
-        idx = blink["epoch_index"]
+        idx = blink.get("epoch_index", -1)
         if 0 <= idx < n_epochs:
             per_epoch[idx].append(blink)
 
-    records = []
-    for epoch_idx, epoch_blinks in enumerate(per_epoch):
-        feats = compute_kinematic_features(epoch_blinks, sfreq)
-        record = {"epoch": epoch_idx}
-        record.update(feats)
+    records: List[Dict[str, float]] = []
+    for epoch_blinks in per_epoch:
+        per_metric: Dict[str, List[float]] = {m: [] for m in _METRICS}
+        for blink in epoch_blinks:
+            start = int(blink["refined_start_frame"])
+            end = int(blink["refined_end_frame"])
+            signal = np.asarray(blink["epoch_signal"], dtype=float)
+            segment = signal[start:end]
+            if segment.size == 0:
+                continue
+            metrics = compute_segment_kinematics(segment, sfreq)
+            for m in _METRICS:
+                per_metric[m].append(metrics[m])
+        record: Dict[str, float] = {}
+        for metric, values in per_metric.items():
+            stats = _safe_stats(values)
+            for stat_name, value in stats.items():
+                record[f"{metric}_{stat_name}"] = value
         records.append(record)
 
-    df = pd.DataFrame.from_records(records).set_index("epoch")
+    df = pd.DataFrame.from_records(records, index=pd.RangeIndex(n_epochs))
     logger.debug("Aggregated kinematic DataFrame shape: %s", df.shape)
     return df
+

--- a/pyblinker/blink_features/kinematics/kinematic_features.py
+++ b/pyblinker/blink_features/kinematics/kinematic_features.py
@@ -1,66 +1,125 @@
-"""Blink kinematic feature calculations."""
-from typing import Any, Dict, List
+"""Blink kinematic feature calculations based on epoch metadata."""
+
+from __future__ import annotations
+
+from typing import Dict, List, Sequence
 
 import logging
 
-from .per_blink import compute_blink_kinematics
-from ..morphology.morphology_features import _safe_stats
+import mne
+import numpy as np
+import pandas as pd
+
+from .per_blink import compute_segment_kinematics
+from ..energy.helpers import _extract_blink_windows, _segment_to_samples, _safe_stats
 
 logger = logging.getLogger(__name__)
 
+_METRICS = (
+    "peak_amp",
+    "t2p",
+    "vel_mean",
+    "vel_peak",
+    "acc_mean",
+    "acc_peak",
+    "rise_time",
+    "fall_time",
+    "auc",
+    "symmetry",
+)
+_STATS = ("mean", "std", "cv")
 
-def compute_kinematic_features(blinks: List[Dict[str, Any]], sfreq: float) -> Dict[str, float]:
-    """Compute aggregated kinematic metrics for a single epoch.
 
-    Blink kinematics describe how quickly and smoothly the eyelids move.
-    Research shows that drowsy drivers exhibit slower peak velocity and
-    acceleration, reduced jerk, and an elevated amplitude-velocity ratio (AVR).
-    These shifts provide sensitive indicators of fatigue-related impairment.
+def _make_columns(ch_names: Sequence[str]) -> List[str]:
+    """Generate ordered column names for all metrics and statistics."""
+
+    columns: List[str] = []
+    for ch in ch_names:
+        for metric in _METRICS:
+            for stat in _STATS:
+                columns.append(f"{metric}_{stat}_{ch}")
+    return columns
+
+
+def compute_kinematic_features(
+    epochs: mne.Epochs, picks: str | Sequence[str] | None = None
+) -> pd.DataFrame:
+    """Compute kinematic blink features for each epoch and channel.
 
     Parameters
     ----------
-    blinks : list of dict
-        Blink annotations belonging to one epoch.
-    sfreq : float
-        Sampling frequency of the recording in Hertz.
+    epochs : mne.Epochs
+        Epochs with metadata containing ``blink_onset`` and ``blink_duration``
+        columns. Blink windows are derived directly from this metadata.
+    picks : str | sequence of str | None, optional
+        Channel name or list of channel names to process. ``None`` uses all
+        available channels.
 
     Returns
     -------
-    dict
-        Dictionary with aggregated kinematic features for the epoch.
+    pandas.DataFrame
+        DataFrame indexed like ``epochs`` containing aggregated statistics of
+        kinematic metrics for each channel.
+
+    Notes
+    -----
+    If an epoch contains no blinks, all kinematic statistics for that epoch
+    are ``NaN``.
     """
-    logger.info("Computing kinematic features for %d blinks", len(blinks))
-    v_maxs: List[float] = []
-    a_maxs: List[float] = []
-    j_maxs: List[float] = []
-    avrs: List[float] = []
 
-    for blink in blinks:
-        single = compute_blink_kinematics(blink, sfreq)
-        v_maxs.append(single["v_max"])
-        a_maxs.append(single["a_max"])
-        j_maxs.append(single["j_max"])
-        avrs.append(single["avr"])
+    if picks is None:
+        ch_names = epochs.ch_names
+    elif isinstance(picks, str):
+        ch_names = [picks]
+    else:
+        ch_names = list(picks)
 
-    stats_v = _safe_stats(v_maxs)
-    stats_a = _safe_stats(a_maxs)
-    stats_j = _safe_stats(j_maxs)
-    stats_avr = _safe_stats(avrs)
+    missing = [ch for ch in ch_names if ch not in epochs.ch_names]
+    if missing:
+        raise ValueError(f"Channels not found: {missing}")
 
-    features = {
-        "blink_velocity_mean": stats_v["mean"],
-        "blink_velocity_std": stats_v["std"],
-        "blink_velocity_cv": stats_v["cv"],
-        "blink_acceleration_mean": stats_a["mean"],
-        "blink_acceleration_std": stats_a["std"],
-        "blink_acceleration_cv": stats_a["cv"],
-        "blink_jerk_mean": stats_j["mean"],
-        "blink_jerk_std": stats_j["std"],
-        "blink_jerk_cv": stats_j["cv"],
-        "blink_avr_mean": stats_avr["mean"],
-        "blink_avr_std": stats_avr["std"],
-        "blink_avr_cv": stats_avr["cv"],
-    }
+    sfreq = float(epochs.info["sfreq"])
+    n_epochs = len(epochs)
+    n_times = epochs.get_data(picks=[ch_names[0]]).shape[-1] if n_epochs else 0
 
-    logger.debug("Kinematic feature values: %s", features)
-    return features
+    columns = _make_columns(ch_names)
+    index = (
+        epochs.metadata.index
+        if isinstance(epochs.metadata, pd.DataFrame)
+        else pd.RangeIndex(n_epochs)
+    )
+    if n_epochs == 0:
+        return pd.DataFrame(index=index, columns=columns, dtype=float)
+
+    data = epochs.get_data(picks=ch_names)
+    records: List[Dict[str, float]] = []
+    logger.info("Computing kinematic features for %d epochs", n_epochs)
+
+    for ei in range(n_epochs):
+        metadata_row = (
+            epochs.metadata.iloc[ei]
+            if isinstance(epochs.metadata, pd.DataFrame)
+            else pd.Series(dtype=float)
+        )
+        windows = _extract_blink_windows(metadata_row)
+        record: Dict[str, float] = {}
+        for ci, ch in enumerate(ch_names):
+            per_metric: Dict[str, List[float]] = {m: [] for m in _METRICS}
+            for onset_s, duration_s in windows:
+                sl = _segment_to_samples(onset_s, duration_s, sfreq, n_times)
+                segment = data[ei, ci, sl]
+                if segment.size == 0:
+                    continue
+                metrics = compute_segment_kinematics(segment, sfreq)
+                for m in _METRICS:
+                    per_metric[m].append(metrics[m])
+            for metric, values in per_metric.items():
+                stats = _safe_stats(values)
+                for stat_name, value in stats.items():
+                    record[f"{metric}_{stat_name}_{ch}"] = value
+        records.append(record)
+
+    df = pd.DataFrame.from_records(records, index=index, columns=columns)
+    logger.debug("Kinematic feature DataFrame shape: %s", df.shape)
+    return df
+

--- a/unit_test/blink_features/energy/test_energy_per_blink_aggregation.py
+++ b/unit_test/blink_features/energy/test_energy_per_blink_aggregation.py
@@ -14,6 +14,7 @@ import pandas as pd
 from pyblinker.blink_features.energy.energy_features import compute_energy_features
 from pyblinker.utils import slice_raw_into_mne_epochs
 from unit_test.blink_features.utils.energy_manual import manual_epoch_energy_features
+from ..utils.helpers import assert_df_has_columns, assert_numeric_or_nan
 
 PROJECT_ROOT = Path(__file__).resolve().parents[3]
 
@@ -53,6 +54,17 @@ class TestEnergyAggregation(unittest.TestCase):
         )
         blink_counts = pd.read_csv(blink_counts_path, index_col="epoch_id")
         df = df.join(blink_counts)
+        metrics = (
+            "blink_signal_energy",
+            "teager_kaiser_energy",
+            "blink_line_length",
+            "blink_velocity_integral",
+        )
+        expected_cols = [
+            f"{m}_{s}_{ch}" for m in metrics for s in ("mean", "std", "cv")
+        ]
+        assert_df_has_columns(self, df, expected_cols + ["blink_count"])
+        assert_numeric_or_nan(self, df.iloc[0])
         sfreq = float(self.epochs.info["sfreq"])
         data = self.epochs.get_data(picks=[ch])
         records = [

--- a/unit_test/blink_features/frequency_domain/test_frequency_domain_blink_features_aggregation.py
+++ b/unit_test/blink_features/frequency_domain/test_frequency_domain_blink_features_aggregation.py
@@ -32,18 +32,17 @@ class TestFrequencyDomainAggregation(unittest.TestCase):
     def test_merge_blink_counts(self) -> None:
         """Joined DataFrame includes blink counts and energies."""
         df = aggregate_frequency_domain_features(self.epochs, picks="EAR-avg_ear")
-        blink_counts = pd.read_csv(
+        blink_counts_path = (
             PROJECT_ROOT / "unit_test" / "test_files" / "ear_eog_blink_count_epoch.csv"
-        ).set_index("epoch_id")
-        merged = df.join(blink_counts)
+        )
+        blink_counts = pd.read_csv(blink_counts_path, index_col="epoch_id")
+        df = df.join(blink_counts)
         assert_df_has_columns(
-            self, merged, [f"wavelet_energy_d{i}" for i in range(1, 5)] + ["blink_count"]
+            self, df, [f"wavelet_energy_d{i}" for i in range(1, 5)] + ["blink_count"]
         )
-        assert_numeric_or_nan(self, merged.iloc[0])
-        self.assertEqual(merged.loc[2, "blink_count"], 0)
-        self.assertTrue(
-            merged.loc[2, [f"wavelet_energy_d{i}" for i in range(1, 5)]].isna().all()
-        )
+        assert_numeric_or_nan(self, df.iloc[0])
+        zero_idx = blink_counts.index[blink_counts["blink_count"] == 0][0]
+        self.assertTrue(df.drop(columns="blink_count").loc[zero_idx].isna().all())
 
 
 if __name__ == "__main__":

--- a/unit_test/blink_features/kinematics/test_kinematic_features.py
+++ b/unit_test/blink_features/kinematics/test_kinematic_features.py
@@ -1,85 +1,105 @@
-"""Kinematic feature extraction tests.
+"""Tests for kinematic blink feature aggregation using epoch metadata."""
 
-Synthetic blink waveforms are produced with ``mock_ear_generation`` for
-``mne.Epochs``-based tests.  Additional tests rely on raw segments taken from
-``ear_eog_raw.fif`` so that real data paths are covered as well.
-"""
+from __future__ import annotations
+
 import unittest
-import math
-import logging
 from pathlib import Path
+
 import mne
+import pandas as pd
 
-from pyblinker.blink_features.kinematics.kinematic_features import compute_kinematic_features
-from unit_test.blink_features.fixtures.mock_ear_generation import _generate_refined_ear
+from pyblinker.blink_features.kinematics import compute_kinematic_features
+from pyblinker.blink_features.kinematics.per_blink import compute_segment_kinematics
+from pyblinker.blink_features.energy.helpers import (
+    _extract_blink_windows,
+    _segment_to_samples,
+    _safe_stats,
+)
+from pyblinker.utils import slice_raw_into_mne_epochs
 
-logger = logging.getLogger(__name__)
+from ..utils.helpers import assert_df_has_columns, assert_numeric_or_nan
 
 
 PROJECT_ROOT = Path(__file__).resolve().parents[3]
 
 
 class TestKinematicFeatures(unittest.TestCase):
-    """Tests for kinematic feature calculations."""
+    """Validate kinematic metrics computed from epoch metadata."""
 
-    def setUp(self) -> None:
-        blinks, sfreq, epoch_len, n_epochs = _generate_refined_ear()
-        self.sfreq = sfreq
-        self.per_epoch = [[] for _ in range(n_epochs)]
-        for blink in blinks:
-            self.per_epoch[blink["epoch_index"]].append(blink)
-
-    def test_first_epoch_features(self) -> None:
-        """Verify kinematic metrics for the first epoch."""
-        feats = compute_kinematic_features(self.per_epoch[0], self.sfreq)
-        logger.debug(f"Kinematic features epoch 0: {feats}")
-        self.assertTrue(math.isclose(feats["blink_velocity_mean"], 9.5))
-        self.assertTrue(math.isclose(feats["blink_acceleration_mean"], 950.0))
-        self.assertTrue(math.isclose(feats["blink_jerk_mean"], 71250.0))
-        self.assertTrue(math.isclose(feats["blink_avr_mean"], 0.02))
-
-    def test_nan_with_no_blinks(self) -> None:
-        """Epoch without blinks should yield NaNs."""
-        feats = compute_kinematic_features(self.per_epoch[3], self.sfreq)
-        logger.debug(f"Kinematic features epoch 3: {feats}")
-        self.assertTrue(math.isnan(feats["blink_velocity_mean"]))
-        self.assertTrue(math.isnan(feats["blink_avr_mean"]))
-
-
-class TestKinematicRealRaw(unittest.TestCase):
-    """Validate kinematic metrics on a real raw segment."""
-
-    def setUp(self) -> None:
+    def setUp(self) -> None:  # noqa: D401
         raw_path = PROJECT_ROOT / "unit_test" / "test_files" / "ear_eog_raw.fif"
         raw = mne.io.read_raw_fif(raw_path, preload=True, verbose=False)
-        self.sfreq = raw.info["sfreq"]
-        start, stop = 0.0, 30.0
-        signal = raw.get_data(picks="EAR-avg_ear", start=int(start * self.sfreq), stop=int(stop * self.sfreq))[0]
-        self.blinks = []
-        for onset, dur in zip(raw.annotations.onset, raw.annotations.duration):
-            if onset >= start and onset + dur <= stop:
-                s = int((onset - start) * self.sfreq)
-                e = int((onset + dur - start) * self.sfreq)
-                peak = (s + e) // 2
-                self.blinks.append(
-                    {
-                        "refined_start_frame": s,
-                        "refined_peak_frame": peak,
-                        "refined_end_frame": e,
-                        "epoch_signal": signal,
-                        "epoch_index": 0,
-                    }
-                )
+        self.epochs = slice_raw_into_mne_epochs(
+            raw, epoch_len=30.0, blink_label=None, progress_bar=False
+        )
 
-    def test_segment_zero_means(self) -> None:
-        """Check a few kinematic metrics for the first segment."""
-        feats = compute_kinematic_features(self.blinks, self.sfreq)
-        logger.debug("Real raw kinematic features: %s", feats)
-        self.assertAlmostEqual(feats["blink_velocity_mean"], 3.90395, places=5)
-        self.assertAlmostEqual(feats["blink_acceleration_mean"], 162.72143, places=5)
-        self.assertAlmostEqual(feats["blink_avr_mean"], 0.0442, places=4)
+    def test_dataframe_and_nan_epochs(self) -> None:
+        """DataFrame has expected columns and NaNs for zero-blink epochs."""
+        ch = "EEG-E8"
+        df = compute_kinematic_features(self.epochs, picks=ch)
+        blink_counts_path = (
+            PROJECT_ROOT / "unit_test" / "test_files" / "ear_eog_blink_count_epoch.csv"
+        )
+        blink_counts = pd.read_csv(blink_counts_path, index_col="epoch_id")
+        df = df.join(blink_counts)
+
+        metrics = [
+            "peak_amp",
+            "t2p",
+            "vel_mean",
+            "vel_peak",
+            "acc_mean",
+            "acc_peak",
+            "rise_time",
+            "fall_time",
+            "auc",
+            "symmetry",
+        ]
+        expected_cols = [f"{m}_{s}_{ch}" for m in metrics for s in ("mean", "std", "cv")]
+        assert_df_has_columns(self, df, expected_cols + ["blink_count"])
+        assert_numeric_or_nan(self, df.iloc[0])
+
+        zero_idx = blink_counts.index[blink_counts["blink_count"] == 0][0]
+        self.assertTrue(df.drop(columns="blink_count").loc[zero_idx].isna().all())
+
+    def test_manual_first_epoch(self) -> None:
+        """Manual computation for the first epoch matches library output."""
+        ch = "EEG-E8"
+        df = compute_kinematic_features(self.epochs, picks=ch)
+        sfreq = float(self.epochs.info["sfreq"])
+        data = self.epochs.get_data(picks=[ch])
+        meta = self.epochs.metadata.iloc[0]
+        windows = _extract_blink_windows(meta)
+        per_metric = {m: [] for m in (
+            "peak_amp",
+            "t2p",
+            "vel_mean",
+            "vel_peak",
+            "acc_mean",
+            "acc_peak",
+            "rise_time",
+            "fall_time",
+            "auc",
+            "symmetry",
+        )}
+        n_times = data.shape[-1]
+        for onset, dur in windows:
+            sl = _segment_to_samples(onset, dur, sfreq, n_times)
+            seg = data[0, 0, sl]
+            metrics = compute_segment_kinematics(seg, sfreq)
+            for m in per_metric:
+                per_metric[m].append(metrics[m])
+
+        manual = {}
+        for metric, values in per_metric.items():
+            stats = _safe_stats(values)
+            for stat_name, value in stats.items():
+                manual[f"{metric}_{stat_name}_{ch}"] = value
+
+        for key, val in manual.items():
+            self.assertAlmostEqual(df.iloc[0][key], val, places=7)
 
 
 if __name__ == "__main__":
-    logging.basicConfig(level=logging.INFO)
     unittest.main()
+


### PR DESCRIPTION
## Summary
- compute detailed blink kinematics from epoch metadata and expose per-channel stats
- verify kinematic aggregation with manual calculations and ensure NaN values for blink-free epochs
- test energy and frequency-domain aggregation with blink counts merged from CSV

## Testing
- `pytest unit_test/blink_features/kinematics/test_kinematic_features.py`
- `pytest unit_test/blink_features/frequency_domain/test_frequency_domain_blink_features_aggregation.py`
- `pytest unit_test/blink_features/energy/test_energy_per_blink_aggregation.py`


------
https://chatgpt.com/codex/tasks/task_e_68abe5242a988325a99cbe8fb49af5c7