### PR TITLE
Add epoch waveform feature computations

### DIFF
--- a/pyblinker/blink_features/waveform_features/aggregate.py
+++ b/pyblinker/blink_features/waveform_features/aggregate.py
@@ -6,10 +6,13 @@ duration and amplitude‑velocity metrics included here.
 
 .. _BLINKER: https://github.com/VisLab/EEG-Blinks
 """
-from typing import Iterable, Dict, Any, List
+from typing import Iterable, Dict, Any, List, Sequence
 import logging
 import pandas as pd
 import numpy as np
+import mne
+
+from ..energy.helpers import _extract_blink_windows, _segment_to_samples
 
 from .features.duration_features import duration_base, duration_zero
 from .features.amp_vel_ratio_features import neg_amp_vel_ratio_zero
@@ -72,4 +75,104 @@ def aggregate_waveform_features(
 
     df = pd.DataFrame.from_records(records).set_index("epoch")
     logger.debug("Aggregated waveform DataFrame shape: %s", df.shape)
+    return df
+
+
+def compute_epoch_waveform_features(
+    epochs: mne.Epochs, picks: str | Sequence[str] | None = None
+) -> pd.DataFrame:
+    """Compute waveform features for each epoch.
+
+    Parameters
+    ----------
+    epochs : mne.Epochs
+        Epochs with metadata containing ``blink_onset`` and
+        ``blink_duration`` entries. These are treated as ground truth and
+        no additional blink detection is performed.
+    picks : str | sequence of str | None, optional
+        Channel name or list of channel names to process. If ``None``, all
+        channels are used.
+
+    Returns
+    -------
+    pandas.DataFrame
+        DataFrame indexed like ``epochs`` with one row per epoch and the
+        mean waveform features for each channel. Base columns without
+        channel suffixes mirror the first channel in ``picks`` for
+        convenience.
+    """
+
+    if picks is None:
+        ch_names = epochs.ch_names
+    elif isinstance(picks, str):
+        ch_names = [picks]
+    else:
+        ch_names = list(picks)
+
+    missing = [ch for ch in ch_names if ch not in epochs.ch_names]
+    if missing:
+        raise ValueError(f"Channels not found: {missing}")
+
+    sfreq = float(epochs.info["sfreq"])
+    n_epochs = len(epochs)
+    n_times = epochs.get_data(picks=[ch_names[0]]).shape[-1] if n_epochs else 0
+
+    base_cols = [
+        "duration_base_mean",
+        "duration_zero_mean",
+        "neg_amp_vel_ratio_zero_mean",
+    ]
+    columns = base_cols + [f"{c}_{ch}" for ch in ch_names for c in base_cols]
+
+    index = (
+        epochs.metadata.index
+        if isinstance(epochs.metadata, pd.DataFrame)
+        else pd.RangeIndex(n_epochs)
+    )
+    if n_epochs == 0:
+        return pd.DataFrame(index=index, columns=columns, dtype=float)
+
+    data = epochs.get_data(picks=ch_names)
+    records: List[Dict[str, float]] = []
+
+    for ei in range(n_epochs):
+        metadata_row = (
+            epochs.metadata.iloc[ei]
+            if isinstance(epochs.metadata, pd.DataFrame)
+            else pd.Series(dtype=float)
+        )
+        windows = _extract_blink_windows(metadata_row)
+        record: Dict[str, float] = {}
+        per_channel: Dict[str, Dict[str, List[float]]] = {
+            ch: {c: [] for c in base_cols} for ch in ch_names
+        }
+        for onset_s, duration_s in windows:
+            sl = _segment_to_samples(onset_s, duration_s, sfreq, n_times)
+            if sl.stop - sl.start <= 1:
+                continue
+            for ci, ch in enumerate(ch_names):
+                blink = {
+                    "refined_start_frame": sl.start,
+                    "refined_end_frame": sl.stop - 1,
+                    "epoch_signal": data[ei, ci],
+                }
+                per_channel[ch]["duration_base_mean"].append(
+                    duration_base(blink, sfreq)
+                )
+                per_channel[ch]["duration_zero_mean"].append(
+                    duration_zero(blink, sfreq)
+                )
+                per_channel[ch]["neg_amp_vel_ratio_zero_mean"].append(
+                    neg_amp_vel_ratio_zero(blink, sfreq)
+                )
+        for ch in ch_names:
+            for col in base_cols:
+                arr = np.asarray(per_channel[ch][col], dtype=float)
+                record[f"{col}_{ch}"] = float(np.nanmean(arr)) if arr.size else float("nan")
+        for col in base_cols:
+            record[col] = record[f"{col}_{ch_names[0]}"]
+        records.append(record)
+
+    df = pd.DataFrame.from_records(records, index=index, columns=columns)
+    logger.debug("Epoch waveform feature DataFrame shape: %s", df.shape)
     return df

--- a/unit_test/blink_features/waveform_features/test_waveform_features.py
+++ b/unit_test/blink_features/waveform_features/test_waveform_features.py
@@ -122,36 +122,6 @@ class TestEpochWaveformFeatures(unittest.TestCase):
         ]
         self.assertTrue(df.loc[no_blink_idx, cols].isna().all())
 
-    def test_waveform_features_aggregation(self) -> None:
-        """Join with blink counts to verify NaNs for blink-free epochs."""
-        feats = compute_epoch_waveform_features(self.epochs)
-        csv_path = (
-            PROJECT_ROOT
-            / "unit_test"
-            / "test_files"
-            / "ear_eog_blink_count_epoch.csv"
-        )
-        counts = pd.read_csv(csv_path)
-        index_col = "epoch_index" if "epoch_index" in counts.columns else "epoch_id"
-        counts = counts.set_index(index_col)
-        merged = feats.join(counts, how="left").rename(
-            columns={"blink_count": "blink_count_epoch"}
-        )
-        cols = [
-            "duration_base_mean",
-            "duration_zero_mean",
-            "neg_amp_vel_ratio_zero_mean",
-        ]
-        zero = merged["blink_count_epoch"] == 0
-        self.assertTrue(merged.loc[zero, cols].isna().all(axis=None))
-        positive = merged["blink_count_epoch"] > 0
-        self.assertTrue(
-            merged.loc[positive, cols]
-            .apply(lambda r: np.isfinite(r).any(), axis=1)
-            .all()
-        )
-        self.assertFalse(np.isinf(merged[cols].to_numpy()).any())
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/unit_test/blink_features/waveform_features/test_waveform_features_aggregation.py
+++ b/unit_test/blink_features/waveform_features/test_waveform_features_aggregation.py
@@ -1,0 +1,64 @@
+"""Aggregation tests for waveform features."""
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+import mne
+import numpy as np
+import pandas as pd
+
+from pyblinker.blink_features.waveform_features.aggregate import (
+    compute_epoch_waveform_features,
+)
+from pyblinker.utils import slice_raw_into_mne_epochs
+
+PROJECT_ROOT = Path(__file__).resolve().parents[3]
+
+
+class TestWaveformFeaturesAggregation(unittest.TestCase):
+    """Verify aggregation behavior when joined with blink counts."""
+
+    def setUp(self) -> None:
+        """Load epochs with blink metadata."""
+        raw_path = (
+            PROJECT_ROOT / "unit_test" / "test_files" / "ear_eog_raw.fif"
+        )
+        raw = mne.io.read_raw_fif(raw_path, preload=True, verbose=False)
+        self.epochs = slice_raw_into_mne_epochs(
+            raw, epoch_len=30.0, blink_label=None, progress_bar=False
+        )
+
+    def test_waveform_features_aggregation(self) -> None:
+        """Join waveform features with blink counts and validate NaN policy."""
+        feats = compute_epoch_waveform_features(self.epochs)
+        csv_path = (
+            PROJECT_ROOT
+            / "unit_test"
+            / "test_files"
+            / "ear_eog_blink_count_epoch.csv"
+        )
+        counts = pd.read_csv(csv_path)
+        index_col = "epoch_index" if "epoch_index" in counts.columns else "epoch_id"
+        counts = counts.set_index(index_col)
+        merged = feats.join(counts, how="left").rename(
+            columns={"blink_count": "blink_count_epoch"}
+        )
+        cols = [
+            "duration_base_mean",
+            "duration_zero_mean",
+            "neg_amp_vel_ratio_zero_mean",
+        ]
+        zero = merged["blink_count_epoch"] == 0
+        self.assertTrue(merged.loc[zero, cols].isna().all(axis=None))
+        positive = merged["blink_count_epoch"] > 0
+        self.assertTrue(
+            merged.loc[positive, cols]
+            .apply(lambda r: np.isfinite(r).any(), axis=1)
+            .all()
+        )
+        self.assertFalse(np.isinf(merged[cols].to_numpy()).any())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `compute_epoch_waveform_features` for extracting blink waveform metrics from epochs with channel support
- test waveform features for schema, blink presence handling, channel picks, empty epochs and CSV aggregation

## Testing
- `pytest unit_test/blink_features/waveform_features/test_waveform_features.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68ad0dd8d3b08325865c3f53b53a2050