### PR TITLE
Fix path handling and expand epoch metadata test

### DIFF
--- a/pyblinker/utils/__init__.py
+++ b/pyblinker/utils/__init__.py
@@ -16,6 +16,7 @@ from .refinement import (
 from .raw_preprocessing import prepare_refined_segments
 from .misc import create_annotation
 from .blink_metadata import onset_entry_to_blinks
+from .report import add_blink_plots_to_report
 
 __all__ = [
     "slice_raw_to_segments",
@@ -31,4 +32,5 @@ __all__ = [
     "prepare_refined_segments",
     "create_annotation",
     "onset_entry_to_blinks",
+    "add_blink_plots_to_report",
 ]

--- a/pyblinker/utils/report.py
+++ b/pyblinker/utils/report.py
@@ -226,7 +226,12 @@ def add_blink_plots_to_report(
 
 def main() -> None:
     """Build a blink validation report for the demo raw file."""
-    raw_path = Path(__file__).resolve().parents[1] / "test_files" / "ear_eog_raw.fif"
+    raw_path = (
+        Path(__file__).resolve().parents[2]
+        / "unit_test"
+        / "test_files"
+        / "ear_eog_raw.fif"
+    )
     raw = mne.io.read_raw_fif(raw_path, preload=True, verbose=False)
     epochs = slice_raw_into_mne_epochs_refine_annot(
         raw, epoch_len=30.0, blink_label="blink", progress_bar=True

--- a/pyblinker/utils/report.py
+++ b/pyblinker/utils/report.py
@@ -233,8 +233,10 @@ def main() -> None:
         / "ear_eog_raw.fif"
     )
     raw = mne.io.read_raw_fif(raw_path, preload=True, verbose=False)
+    # The demo annotations are not labeled "blink"; treat all annotations as
+    # candidate blink intervals to populate the metadata.
     epochs = slice_raw_into_mne_epochs_refine_annot(
-        raw, epoch_len=30.0, blink_label="blink", progress_bar=True
+        raw, epoch_len=30.0, blink_label=None, progress_bar=True
     )
     report = add_blink_plots_to_report(
         epochs,

--- a/pyblinker/utils/report.py
+++ b/pyblinker/utils/report.py
@@ -45,6 +45,8 @@ def add_blink_plots_to_report(
 ) -> mne.Report:
     """
     Add per-epoch/per-blink/per-channel plots into an MNE Report for validation.
+    Signals are shown with semi-transparent lines and large sample markers to aid
+    visual inspection.
 
     Parameters
     ----------
@@ -174,8 +176,17 @@ def add_blink_plots_to_report(
                         t = t_seg
 
                     fig, ax = plt.subplots(figsize=(7.5, 3.0))
-                    ax.plot(t, y, lw=1.0)
-                    ax.set_title(f"Epoch {ei} • Blink {bi} • {mod.upper()} • {ch_name}")
+                    line = ax.plot(t, y, lw=1.0, alpha=0.6)[0]
+                    ax.scatter(
+                        t,
+                        y,
+                        s=25.0,
+                        color=line.get_color(),
+                        zorder=3,
+                    )
+                    ax.set_title(
+                        f"Epoch {ei} • Blink {bi} • {mod.upper()} • {ch_name}"
+                    )
                     ax.set_xlabel("Time from epoch start (s)")
                     ax.set_ylabel("Amplitude")
 

--- a/tutorial/epoching_and_blink_validation_report.py
+++ b/tutorial/epoching_and_blink_validation_report.py
@@ -43,17 +43,12 @@ def main() -> None:
     md = epochs.metadata.copy()
     md["epoch_id"] = md.index
     merged = md.merge(blink_counts, on="epoch_id", how="left")
-    counts_match = (
+    if not (
         merged["n_blinks"].fillna(0).astype(int)
         == merged["blink_count"].fillna(0).astype(int)
-    )
-    if counts_match.all():
-        logger.info("Blink counts in metadata align with CSV")
-    else:
-        logger.warning(
-            "CSV blink counts do not match metadata n_blinks:\n%s",
-            merged.loc[~counts_match, ["epoch_id", "n_blinks", "blink_count"]],
-        )
+    ).all():
+        raise AssertionError("CSV blink counts do not match metadata n_blinks")
+    logger.info("Blink counts in metadata align with CSV")
 
     report = add_blink_plots_to_report(
         epochs,

--- a/tutorial/epoching_and_blink_validation_report.py
+++ b/tutorial/epoching_and_blink_validation_report.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import mne
 
 from refine_annotation.util import slice_raw_into_mne_epochs_refine_annot
-from unit_test.epoch_refine_annotation.report import add_blink_plots_to_report
+from pyblinker.utils.report import add_blink_plots_to_report
 
 logger = logging.getLogger(__name__)
 

--- a/tutorial/epoching_and_blink_validation_report.py
+++ b/tutorial/epoching_and_blink_validation_report.py
@@ -1,0 +1,43 @@
+"""Tutorial demonstrating epoching and blink validation report generation."""
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import mne
+
+from refine_annotation.util import slice_raw_into_mne_epochs_refine_annot
+from unit_test.epoch_refine_annotation.report import add_blink_plots_to_report
+
+logger = logging.getLogger(__name__)
+
+
+def main() -> None:
+    """Build epochs and create a blink validation report."""
+    raw_path = (
+        Path(__file__).resolve().parents[1]
+        / "unit_test"
+        / "test_files"
+        / "ear_eog_raw.fif"
+    )
+    raw = mne.io.read_raw_fif(raw_path, preload=True, verbose=False)
+    epochs = slice_raw_into_mne_epochs_refine_annot(
+        raw, epoch_len=30.0, blink_label="blink", progress_bar=True
+    )
+    report = add_blink_plots_to_report(
+        epochs,
+        pad_pre=0.5,
+        pad_post=0.5,
+        limit_per_epoch=None,
+        decim=2,
+        include_modalities=("eeg", "eog", "ear"),
+        progress_bar=True,
+    )
+    out_path = Path("blink_validation_report.html")
+    report.save(out_path, overwrite=True)
+    logger.info("Saved blink report to %s", out_path)
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    main()

--- a/tutorial/epoching_and_blink_validation_report.py
+++ b/tutorial/epoching_and_blink_validation_report.py
@@ -21,8 +21,10 @@ def main() -> None:
         / "ear_eog_raw.fif"
     )
     raw = mne.io.read_raw_fif(raw_path, preload=True, verbose=False)
+    # Treat all annotations as blink candidates since the demo file does not
+    # use the label "blink" for its events.
     epochs = slice_raw_into_mne_epochs_refine_annot(
-        raw, epoch_len=30.0, blink_label="blink", progress_bar=True
+        raw, epoch_len=30.0, blink_label=None, progress_bar=True
     )
     report = add_blink_plots_to_report(
         epochs,


### PR DESCRIPTION
## Summary
- ensure `TestFromFile` stores the loaded raw file to fix path lookup failures
- add regression check merging epoch metadata with blink counts to illustrate empty epochs

## Testing
- `python -m pytest unit_test/epoch_refine_annotation/test_refine_annot_by_channel.py`

------
https://chatgpt.com/codex/tasks/task_e_68ad6c829ca08325bd370dd71260b03c