### PR TITLE
refactor: use refined epoch slicing in energy aggregation test

### DIFF
--- a/unit_test/blink_features/energy/test_energy_per_blink_aggregation.py
+++ b/unit_test/blink_features/energy/test_energy_per_blink_aggregation.py
@@ -12,7 +12,7 @@ import mne
 import pandas as pd
 
 from pyblinker.blink_features.energy.energy_features import compute_energy_features
-from pyblinker.utils import slice_raw_into_mne_epochs
+from refine_annotation.util import slice_raw_into_mne_epochs_refine_annot
 from unit_test.blink_features.utils.energy_manual import manual_epoch_energy_features
 from ..utils.helpers import assert_df_has_columns, assert_numeric_or_nan
 
@@ -30,7 +30,7 @@ class TestEnergyAggregation(unittest.TestCase):
             / "ear_eog_raw.fif"
         )
         raw = mne.io.read_raw_fif(raw_path, preload=True, verbose=False)
-        self.epochs = slice_raw_into_mne_epochs(
+        self.epochs = slice_raw_into_mne_epochs_refine_annot(
             raw, epoch_len=30.0, blink_label=None, progress_bar=False
         )
 


### PR DESCRIPTION
## Summary
- use slice_raw_into_mne_epochs_refine_annot in per-blink energy aggregation test to leverage refined blink annotations

## Testing
- `pytest unit_test/blink_features/energy/test_energy_per_blink_aggregation.py`

------
https://chatgpt.com/codex/tasks/task_e_68aefbe30690832582ad74c31ab78f07