### PR TITLE
Attach epoch-level blink metadata

### DIFF
--- a/pyblinker/utils/blink_metadata.py
+++ b/pyblinker/utils/blink_metadata.py
@@ -3,6 +3,8 @@
 import logging
 from typing import Any, Dict, List
 
+import mne
+import numpy as np
 import pandas as pd
 
 logger = logging.getLogger(__name__)
@@ -32,3 +34,104 @@ def onset_entry_to_blinks(onset: Any) -> List[Dict[str, float]]:
     logger.debug("Converted %s to %d blink entries", onset, len(blinks))
     logger.info("Exiting onset_entry_to_blinks")
     return blinks
+
+
+def attach_blink_metadata(epochs: mne.Epochs, blink_df: pd.DataFrame) -> pd.DataFrame:
+    """Aggregate per-blink properties and merge them into epoch metadata.
+
+    Parameters
+    ----------
+    epochs : mne.Epochs
+        Epoch container whose ``metadata`` will be updated in-place. The
+        ``selection`` attribute is used to map original segment indices to kept
+        epoch indices.
+    blink_df : pandas.DataFrame
+        Long-format blink table returned by
+        :func:`pyblinker.segment_blink_properties.compute_segment_blink_properties`.
+        Must contain at least ``seg_id``, ``blink_id``, ``start_blink`` and
+        ``end_blink`` columns measured in samples.
+
+    Returns
+    -------
+    pandas.DataFrame
+        Filtered long-format blink table containing only rows from epochs that
+        remain after any ``Epochs`` dropping operations. This table is detached
+        from ``epochs.metadata`` so that downstream code can operate on
+        per-blink rows directly.
+    """
+    logger.info("Entering attach_blink_metadata")
+
+    sfreq = float(epochs.info["sfreq"])
+    selection_map = {orig: new for new, orig in enumerate(epochs.selection)}
+
+    df = blink_df.copy()
+    df["epoch_index"] = df["seg_id"].map(selection_map)
+    df = df.dropna(subset=["epoch_index"]).reset_index(drop=True)
+    df["epoch_index"] = df["epoch_index"].astype(int)
+
+    df["blink_onset"] = df["start_blink"] / sfreq
+    df["blink_duration"] = (df["end_blink"] - df["start_blink"]) / sfreq
+
+    group = df.groupby("epoch_index")
+    n_epochs = len(epochs)
+    epoch_meta = pd.DataFrame(index=range(n_epochs))
+    epoch_meta["n_blinks"] = group.size().reindex(epoch_meta.index, fill_value=0)
+
+    def _list_or_nan(series: pd.Series) -> object:
+        values = series.dropna().tolist()
+        return values if values else float("nan")
+
+    epoch_meta["blink_onset"] = group["blink_onset"].apply(_list_or_nan).reindex(
+        epoch_meta.index
+    )
+    epoch_meta["blink_duration"] = group["blink_duration"].apply(_list_or_nan).reindex(
+        epoch_meta.index
+    )
+    epoch_meta["blink_first_onset_s"] = group["blink_onset"].min().reindex(
+        epoch_meta.index
+    )
+    epoch_meta["blink_max_duration_s"] = group["blink_duration"].max().reindex(
+        epoch_meta.index
+    )
+
+    exclude = {
+        "seg_id",
+        "blink_id",
+        "start_blink",
+        "end_blink",
+        "outer_start",
+        "outer_end",
+        "epoch_index",
+        "blink_onset",
+        "blink_duration",
+    }
+    numeric_cols = [
+        c
+        for c in df.select_dtypes(include=[np.number]).columns
+        if c not in exclude
+    ]
+    if numeric_cols:
+        summary = group[numeric_cols].agg(["max", "mean"])
+        summary.columns = [f"{col}_{stat}" for col, stat in summary.columns]
+        summary = summary.reindex(epoch_meta.index)
+        epoch_meta = pd.concat([epoch_meta, summary], axis=1)
+
+    epoch_meta.index.name = None
+
+    existing = (
+        epochs.metadata.copy()
+        if isinstance(epochs.metadata, pd.DataFrame)
+        else pd.DataFrame(index=range(n_epochs))
+    )
+    existing = existing.reset_index(drop=True)
+    keep_cols = [
+        c
+        for c in existing.columns
+        if (c not in epoch_meta.columns) and not (c.startswith("blink_") or c == "n_blinks")
+    ]
+    merged = existing[keep_cols].join(epoch_meta)
+    epochs.metadata = merged
+    epochs.metadata.reset_index(drop=True, inplace=True)
+
+    logger.info("Exiting attach_blink_metadata")
+    return df.drop(columns=["epoch_index"])

--- a/unit_test/blink_features/segmented_continous_annotated_raw/test_attach_blink_metadata.py
+++ b/unit_test/blink_features/segmented_continous_annotated_raw/test_attach_blink_metadata.py
@@ -1,0 +1,75 @@
+"""Tests for attaching blink metadata to epochs."""
+
+import logging
+from pathlib import Path
+import unittest
+
+import mne
+import numpy as np
+import pandas as pd
+
+from refine_annotation.util import slice_raw_into_mne_epochs_refine_annot
+from pyblinker.segment_blink_properties import compute_segment_blink_properties
+from pyblinker.utils.blink_metadata import attach_blink_metadata
+
+logger = logging.getLogger(__name__)
+
+PROJECT_ROOT = Path(__file__).resolve().parents[3]
+
+
+class TestAttachBlinkMetadata(unittest.TestCase):
+    """Validate epoch-level blink metadata aggregation."""
+
+    def setUp(self) -> None:
+        """Load epochs and compute blink properties."""
+        raw_path = PROJECT_ROOT / "unit_test" / "test_files" / "ear_eog_raw.fif"
+        raw = mne.io.read_raw_fif(raw_path, preload=True, verbose=False)
+        epochs_full = slice_raw_into_mne_epochs_refine_annot(
+            raw, epoch_len=30.0, blink_label=None, progress_bar=False
+        )
+        self.params = {
+            "base_fraction": 0.5,
+            "shut_amp_fraction": 0.9,
+            "p_avr_threshold": 3,
+            "z_thresholds": np.array([[0.9, 0.98], [2.0, 5.0]]),
+        }
+        blink_epochs = compute_segment_blink_properties(
+            epochs_full, self.params, channel="EEG-E8", progress_bar=False
+        )
+        self.blink_df = blink_epochs.metadata.copy()
+        # Drop the first epoch to exercise selection mapping
+        self.epochs = epochs_full.copy().drop([0])
+
+    def test_metadata_attachment(self) -> None:
+        """Blink metadata merged correctly and long table returned."""
+        long_df = attach_blink_metadata(self.epochs, self.blink_df)
+        md = self.epochs.metadata
+
+        self.assertEqual(len(md), len(self.epochs))
+        self.assertListEqual(list(md.index), list(range(len(self.epochs))))
+
+        for _, row in md.iterrows():
+            if row["n_blinks"] == 0:
+                self.assertTrue(pd.isna(row["blink_onset"]))
+                self.assertTrue(pd.isna(row["blink_duration"]))
+            else:
+                self.assertEqual(len(row["blink_onset"]), row["n_blinks"])
+                self.assertEqual(len(row["blink_duration"]), row["n_blinks"])
+
+        # Numeric summaries allow selection
+        _ = self.epochs[self.epochs.metadata["n_blinks"] >= 0]
+
+        # Long table only includes kept epochs
+        self.assertTrue(set(long_df["seg_id"]).issubset(set(self.epochs.selection)))
+
+    def test_idempotent(self) -> None:
+        """Repeated attachment updates only blink columns."""
+        attach_blink_metadata(self.epochs, self.blink_df)
+        md_first = self.epochs.metadata.copy()
+        attach_blink_metadata(self.epochs, self.blink_df)
+        pd.testing.assert_frame_equal(self.epochs.metadata, md_first)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    logging.basicConfig(level=logging.INFO)
+    unittest.main()


### PR DESCRIPTION
## Summary
- aggregate per-blink properties into epoch-level metadata and merge with existing epoch info
- keep filtered per-blink table separate for downstream processing
- add tests confirming metadata attachment and idempotent updates

## Testing
- `pytest unit_test/blink_features/segmented_continous_annotated_raw/test_attach_blink_metadata.py unit_test/blink_features/segmented_continous_annotated_raw/test_segment_blink_properties.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b05b1a8d408325b2737dc38b92e8e8