### PR TITLE
refactor: replace deprecated trapz usage and gate fit warnings

### DIFF
--- a/pyblinker/blink_features/energy/per_blink.py
+++ b/pyblinker/blink_features/energy/per_blink.py
@@ -44,7 +44,7 @@ def compute_blink_energy(blink: Dict[str, Any], sfreq: float) -> Dict[str, float
             "blink_velocity_integral": float("nan"),
         }
 
-    energy = float(np.trapz(segment ** 2, dx=dt))
+    energy = float(np.trapezoid(segment ** 2, dx=dt))
 
     if segment.size > 2:
         tkeo = segment[1:-1] ** 2 - segment[:-2] * segment[2:]
@@ -55,7 +55,7 @@ def compute_blink_energy(blink: Dict[str, Any], sfreq: float) -> Dict[str, float
     line_length = float(np.sum(np.abs(np.diff(segment))))
 
     velocity = np.gradient(segment, dt)
-    vel_integral = float(np.trapz(np.abs(velocity), dx=dt))
+    vel_integral = float(np.trapezoid(np.abs(velocity), dx=dt))
 
     logger.debug(
         "Blink energy: energy=%s, teager=%s, line_length=%s, vel_int=%s",

--- a/pyblinker/blink_features/energy/segment_features.py
+++ b/pyblinker/blink_features/energy/segment_features.py
@@ -23,7 +23,7 @@ def compute_time_domain_features(signal: np.ndarray, sfreq: float) -> Dict[str, 
     """
     logger.info("Computing time-domain features for segment of length %d", len(signal))
     dt = 1.0 / sfreq
-    energy = float(np.trapz(signal ** 2, dx=dt))
+    energy = float(np.trapezoid(signal ** 2, dx=dt))
 
     if signal.size > 2:
         tkeo = signal[1:-1] ** 2 - signal[:-2] * signal[2:]
@@ -33,7 +33,7 @@ def compute_time_domain_features(signal: np.ndarray, sfreq: float) -> Dict[str, 
 
     line_length = float(np.sum(np.abs(np.diff(signal))))
     velocity = np.gradient(signal, dt)
-    velocity_integral = float(np.trapz(np.abs(velocity), dx=dt))
+    velocity_integral = float(np.trapezoid(np.abs(velocity), dx=dt))
 
     features = {
         "energy": energy,

--- a/pyblinker/blink_features/morphology/per_blink.py
+++ b/pyblinker/blink_features/morphology/per_blink.py
@@ -44,7 +44,7 @@ def compute_blink_waveform_metrics(segment: np.ndarray, sfreq: float) -> Optiona
     peak = float(segment[peak_idx])
     trough = float(segment[trough_idx])
     peak_to_peak = float(peak - trough)
-    area_abs = float(np.trapz(np.abs(segment), dx=1.0 / sfreq))
+    area_abs = float(np.trapezoid(np.abs(segment), dx=1.0 / sfreq))
 
     rise_time = peak_idx / sfreq
     fall_time = (segment.size - 1 - peak_idx) / sfreq

--- a/pyblinker/blinker/fit_blink.py
+++ b/pyblinker/blinker/fit_blink.py
@@ -1,5 +1,7 @@
-import numpy as np
+import logging
 import warnings
+
+import numpy as np
 import pandas as pd
 
 from .zero_crossing import (
@@ -9,6 +11,9 @@ from .zero_crossing import (
 )
 from .base_left_right import create_left_right_base
 from ..fitutils.line_intersection import lines_intersection
+
+
+logger = logging.getLogger(__name__)
 
 
 class FitBlinks:
@@ -114,10 +119,10 @@ class FitBlinks:
         self.frame_blinks = create_left_right_base(self.candidate_signal, self.df)
 
         if run_fit:
-            warnings.warn(
-                "Running fit() may drop blinks due to NaNs in fit range",
-                RuntimeWarning,
-            )
+            msg = "Running fit() may drop blinks due to NaNs in fit range"
+            logger.warning(msg)
+            if logger.isEnabledFor(logging.DEBUG):
+                warnings.warn(msg, RuntimeWarning)
             self.fit()
 
     def dprocess(self, *, run_fit: bool = True) -> None:

--- a/test/blink_features/full_epoch_feature_pipeline/test_segment_raw_feature_pipeline.py
+++ b/test/blink_features/full_epoch_feature_pipeline/test_segment_raw_feature_pipeline.py
@@ -79,15 +79,21 @@ class TestSegmentRawFeaturePipeline(unittest.TestCase):
         df_energy = pd.DataFrame(energy_rows)
 
         if run_fit:
-            with self.assertWarns(RuntimeWarning):
-                blink_props = compute_segment_blink_properties(
-                    self.segments,
-                    self.params,
-                    blink_df=self.blink_df,
-                    channel="EEG-E8",
-                    run_fit=run_fit,
-                    progress_bar=False,
-                )
+            fit_logger = logging.getLogger("pyblinker.blinker.fit_blink")
+            prev_level = fit_logger.level
+            fit_logger.setLevel(logging.DEBUG)
+            try:
+                with self.assertWarns(RuntimeWarning):
+                    blink_props = compute_segment_blink_properties(
+                        self.segments,
+                        self.params,
+                        blink_df=self.blink_df,
+                        channel="EEG-E8",
+                        run_fit=run_fit,
+                        progress_bar=False,
+                    )
+            finally:
+                fit_logger.setLevel(prev_level)
         else:
             blink_props = compute_segment_blink_properties(
                 self.segments,


### PR DESCRIPTION
## Summary
- replace deprecated `np.trapz` with `np.trapezoid` in blink feature calculations to avoid deprecation warnings
- log potential blink drops during fitting and only emit a runtime warning when debug logging is enabled
- adjust segment-level pipeline test to trigger the warning only under debug logging

## Testing
- `pip install PyWavelets`
- `ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b14ed9dbc0832583751a8780cfb075