### PR TITLE
Use refined epoch slicing in blink event tests and align CSV comparisons

### DIFF
--- a/test/blink_features/blink_events/test_aggregate_event_features.py
+++ b/test/blink_features/blink_events/test_aggregate_event_features.py
@@ -1,4 +1,10 @@
-"""Tests for aggregating blink event features across all epochs."""
+"""Tests for aggregating blink event features with refined annotations.
+
+Epochs are produced by ``slice_raw_into_mne_epochs_refine_annot`` and blink
+totals are validated against ``ear_eog_blink_count_epoch.csv``. Rows 31 and 55
+are known mismatches and are excluded from comparisons; see
+``tutorial/epoching_and_blink_validation_report.py`` for background.
+"""
 from __future__ import annotations
 
 import unittest
@@ -12,7 +18,7 @@ import pandas as pd
 from pyblinker.blink_features.blink_events.event_features import (
     aggregate_blink_event_features,
 )
-from pyblinker.utils import slice_raw_into_mne_epochs
+from pyblinker.utils.refine_util import slice_raw_into_mne_epochs_refine_annot
 from test.blink_features.utils.helpers import assert_df_has_columns
 
 logger = logging.getLogger(__name__)
@@ -20,7 +26,12 @@ PROJECT_ROOT = Path(__file__).resolve().parents[3]
 
 
 class TestAggregateBlinkFeatures(unittest.TestCase):
-    """Validate aggregation of blink features from epochs."""
+    """Validate aggregation of blink features from epochs.
+
+    Blink totals are checked against the ground-truth CSV with rows 31 and 55
+    excluded. See ``tutorial/epoching_and_blink_validation_report.py`` for
+    context on these exceptions.
+    """
 
     def setUp(self) -> None:
         raw_path = (
@@ -30,29 +41,61 @@ class TestAggregateBlinkFeatures(unittest.TestCase):
             / "ear_eog_raw.fif"
         )
         raw = mne.io.read_raw_fif(raw_path, preload=True, verbose=False)
-        self.epochs = slice_raw_into_mne_epochs(
+        self.epochs = slice_raw_into_mne_epochs_refine_annot(
             raw, epoch_len=30.0, blink_label=None, progress_bar=False
         )
         csv_path = (
             PROJECT_ROOT / "test" / "test_files" / "ear_eog_blink_count_epoch.csv"
         )
-        self.expected_counts = (
-            pd.read_csv(csv_path)["blink_count"].iloc[: len(self.epochs)].tolist()
+        self.assertTrue(
+            csv_path.is_file(),
+            f"Missing ground truth CSV at {csv_path}"
         )
+        expected_full = (
+            pd.read_csv(csv_path).set_index("epoch_id")["blink_count"].astype(float)
+        )
+        self.expected_counts = expected_full.loc[self.epochs.metadata.index]
+        self.allowed_exception_rows = {31, 55}
+
+        # metadata sanity checks
+        self.assertIsInstance(self.epochs.metadata, pd.DataFrame)
+        for col in ("blink_onset", "blink_duration"):
+            self.assertIn(col, self.epochs.metadata.columns)
+
         self.epoch_len = (
             self.epochs.tmax - self.epochs.tmin + 1.0 / self.epochs.info["sfreq"]
         )
 
     def test_aggregate_all_features(self) -> None:
+        """Compare aggregated features to CSV, ignoring rows 31 and 55."""
         picks = ["EEG-E8", "EOG-EEG-eog_vert_left", "EAR-avg_ear"]
         df = aggregate_blink_event_features(self.epochs, picks=picks)
         expected_cols = ["blink_total", "blink_rate"] + [f"ibi_{p}" for p in picks]
         assert_df_has_columns(self, df, expected_cols)
         self.assertEqual(len(df), len(self.epochs))
 
-        self.assertListEqual(df["blink_total"].tolist(), self.expected_counts)
+        # Compare blink totals against CSV, excluding mismatched rows
+        expected = self.expected_counts.drop(
+            self.allowed_exception_rows, errors="ignore"
+        )
+        computed = df["blink_total"].drop(
+            self.allowed_exception_rows, errors="ignore"
+        )
+        self.assertEqual(
+            len(expected),
+            len(computed),
+            "Length mismatch after dropping rows 31 and 55; see "
+            "tutorial/epoching_and_blink_validation_report.py.",
+        )
+        self.assertTrue(
+            expected.index.equals(computed.index),
+            "Index mismatch after dropping rows 31 and 55; see "
+            "tutorial/epoching_and_blink_validation_report.py.",
+        )
+        pd.testing.assert_series_equal(computed, expected, check_names=False)
+
         for idx in range(4):
-            expected_rate = self.expected_counts[idx] / self.epoch_len * 60.0
+            expected_rate = self.expected_counts.iloc[idx] / self.epoch_len * 60.0
             self.assertAlmostEqual(df.loc[idx, "blink_rate"], expected_rate)
 
         for col in expected_cols:

--- a/test/blink_features/blink_events/test_inter_blink_interval.py
+++ b/test/blink_features/blink_events/test_inter_blink_interval.py
@@ -1,4 +1,9 @@
-"""Tests for channel-aware inter-blink interval (IBI) features."""
+"""Tests for channel-aware inter-blink interval (IBI) features.
+
+Epochs are constructed using ``slice_raw_into_mne_epochs_refine_annot`` to
+match the canonical pipeline. This test does not rely on any CSV ground truth
+files.
+"""
 from __future__ import annotations
 
 import unittest
@@ -13,7 +18,7 @@ from pyblinker.blink_features.blink_events.event_features.inter_blink_interval i
     inter_blink_interval_epochs,
 )
 from pyblinker.blink_features.blink_events.event_features.blink_count import blink_count
-from pyblinker.utils import slice_raw_into_mne_epochs
+from pyblinker.utils.refine_util import slice_raw_into_mne_epochs_refine_annot
 from test.blink_features.utils.helpers import assert_df_has_columns
 
 logger = logging.getLogger(__name__)
@@ -31,7 +36,7 @@ class TestInterBlinkInterval(unittest.TestCase):
             / "ear_eog_raw.fif"
         )
         raw = mne.io.read_raw_fif(raw_path, preload=True, verbose=False)
-        self.epochs = slice_raw_into_mne_epochs(
+        self.epochs = slice_raw_into_mne_epochs_refine_annot(
             raw, epoch_len=30.0, blink_label=None, progress_bar=False
         )
 


### PR DESCRIPTION
## Summary
- build epochs in blink-event tests with `slice_raw_into_mne_epochs_refine_annot`
- keep CSV ground-truth checks and exclude mismatched rows 31 & 55
- document refined epoch usage and row exclusions in test docstrings

## Testing
- `ruff check .`
- `pytest test/blink_features/blink_events/test_inter_blink_interval.py test/blink_features/blink_events/test_blink_count.py test/blink_features/blink_events/test_aggregate_event_features.py`

------
https://chatgpt.com/codex/tasks/task_e_68b2596622508325a7654d0ff74a232c