### PR TITLE
Add epoch index column to frequency-domain blink features

### DIFF
--- a/test/blink_features/blink_events/test_aggregate_event_features.py
+++ b/test/blink_features/blink_events/test_aggregate_event_features.py
@@ -70,9 +70,12 @@ class TestAggregateBlinkFeatures(unittest.TestCase):
         """Compare aggregated features to CSV, ignoring rows 31 and 55."""
         picks = ["EEG-E8", "EOG-EEG-eog_vert_left", "EAR-avg_ear"]
         df = aggregate_blink_event_features(self.epochs, picks=picks)
-        expected_cols = ["blink_total", "blink_rate"] + [f"ibi_{p}" for p in picks]
+        expected_cols = ["ep", "blink_total", "blink_rate"] + [f"ibi_{p}" for p in picks]
         assert_df_has_columns(self, df, expected_cols)
         self.assertEqual(len(df), len(self.epochs))
+        pd.testing.assert_series_equal(
+            df["ep"], pd.Series(self.epochs.metadata.index, name="ep"), check_names=False
+        )
 
         # Compare blink totals against CSV, excluding mismatched rows
         expected = self.expected_counts.drop(

--- a/test/blink_features/frequency_domain/test_frequency_domain_blink_features_aggregation.py
+++ b/test/blink_features/frequency_domain/test_frequency_domain_blink_features_aggregation.py
@@ -31,21 +31,27 @@ class TestFrequencyDomainAggregation(unittest.TestCase):
 
     def test_merge_blink_counts(self) -> None:
         """Joined DataFrame includes blink counts and energies."""
-        df = aggregate_frequency_domain_features(self.epochs, picks="EAR-avg_ear")
+        df = aggregate_frequency_domain_features(
+            self.epochs, picks="EAR-avg_ear", progress_bar=False
+        )
         blink_counts_path = (
             PROJECT_ROOT / "test" / "test_files" / "ear_eog_blink_count_epoch.csv"
         )
         blink_counts = pd.read_csv(blink_counts_path, index_col="epoch_id")
         df = df.join(blink_counts)
         assert_df_has_columns(
-            self, df, [f"wavelet_energy_d{i}" for i in range(1, 5)] + ["blink_count"]
+            self,
+            df,
+            ["ep"]
+            + [f"wavelet_energy_d{i}" for i in range(1, 5)]
+            + ["blink_count"],
         )
-        assert_numeric_or_nan(self, df.iloc[0])
+        assert_numeric_or_nan(self, df.drop(columns=["ep"]).iloc[0])
         zero_idx = self.epochs.metadata.index[
             self.epochs.metadata["blink_onset"].isna()
         ][0]
         self.assertTrue(
-            df.drop(columns="blink_count").loc[zero_idx].isna().all()
+            df.drop(columns=["ep", "blink_count"]).loc[zero_idx].isna().all()
         )
 
 


### PR DESCRIPTION
## Summary
- Include an `ep` column in frequency-domain, inter-blink interval, and blink count feature results for explicit epoch IDs
- Derive blink counts and inter-blink intervals from modality-specific blink onset/duration metadata with fallback to generic columns
- Document modality-specific metadata handling and confirm via new unit tests

## Testing
- `ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b5a275e9dc8325bdc112a56fddff65