### PR TITLE
Improve input validation for create_annotation

### DIFF
--- a/pyblinker/utils/misc.py
+++ b/pyblinker/utils/misc.py
@@ -1,19 +1,77 @@
+"""Miscellaneous helper utilities."""
+
+from __future__ import annotations
+
+import logging
+
 import mne
 import pandas as pd
 
-def create_annotation(sblink, sfreq, label):
+logger = logging.getLogger(__name__)
 
 
+def create_annotation(
+    sblink: pd.DataFrame,
+    sfreq: float,
+    label: str,
+) -> mne.Annotations:
+    """Convert blink spans into an :class:`mne.Annotations` object.
+
+    Parameters
+    ----------
+    sblink : pandas.DataFrame
+        DataFrame containing ``start_blink`` and ``end_blink`` columns with
+        blink sample indices.
+    sfreq : float
+        Sampling frequency of the signal in Hertz. Must be positive.
+    label : str
+        Annotation label applied to each blink.
+
+    Returns
+    -------
+    mne.Annotations
+        Annotation object describing the blinks.
+
+    Raises
+    ------
+    TypeError
+        If ``sblink`` is not a DataFrame or ``label`` is not a string.
+    ValueError
+        If required columns are missing or ``sfreq`` is non-positive.
+    """
+
+    logger.info("Entering create_annotation")
     if not isinstance(sblink, pd.DataFrame):
-        raise ValueError('No appropriate channel. sorry. Try to use large channel selection')
+        raise TypeError("sblink must be a pandas.DataFrame")
 
+    required_cols = {"start_blink", "end_blink"}
+    missing = required_cols - set(sblink.columns)
+    if missing:
+        missing_cols = ", ".join(sorted(missing))
+        raise ValueError(
+            f"sblink is missing required columns: {missing_cols}",
+        )
 
-    onset = (sblink['start_blink'] / sfreq).tolist()
-    duration= (sblink['end_blink'] - sblink['start_blink']) / sfreq
-    des_s = [label] * len(onset)
+    if not isinstance(sfreq, (int, float)) or sfreq <= 0:
+        raise ValueError("sfreq must be a positive number")
 
-    annot = mne.Annotations(onset=onset,  # in seconds
-                            duration=duration,  # in seconds, too
-                            description=des_s)
+    if not isinstance(label, str) or not label:
+        raise TypeError("label must be a non-empty string")
 
+    onset = (sblink["start_blink"] / sfreq).to_list()
+    duration = (
+        (sblink["end_blink"] - sblink["start_blink"]) / sfreq
+    ).to_list()
+    descriptions = [label] * len(onset)
+
+    annot = mne.Annotations(
+        onset=onset,
+        duration=duration,
+        description=descriptions,
+    )
+    logger.info("Exiting create_annotation")
     return annot
+
+
+__all__ = ["create_annotation"]
+

--- a/test/utils/test_create_annotation.py
+++ b/test/utils/test_create_annotation.py
@@ -1,0 +1,53 @@
+"""Tests for the :func:`create_annotation` utility."""
+
+import logging
+import unittest
+
+import mne
+import pandas as pd
+
+from pyblinker.utils import create_annotation
+
+logger = logging.getLogger(__name__)
+
+
+class TestCreateAnnotation(unittest.TestCase):
+    """Validate annotation creation and input checking."""
+
+    def test_valid_dataframe(self) -> None:
+        """A valid DataFrame should yield an annotation object."""
+        df = pd.DataFrame({"start_blink": [0, 30], "end_blink": [15, 45]})
+        annot = create_annotation(df, 30.0, "blink")
+        self.assertIsInstance(annot, mne.Annotations)
+        self.assertEqual(annot.onset.tolist(), [0.0, 1.0])
+        self.assertEqual(annot.duration.tolist(), [0.5, 0.5])
+        self.assertEqual(annot.description.tolist(), ["blink", "blink"])
+
+    def test_non_dataframe_input_raises(self) -> None:
+        """Non-DataFrame input should raise a ``TypeError``."""
+        with self.assertRaises(TypeError):
+            create_annotation([], 30.0, "blink")
+
+    def test_missing_columns_raises(self) -> None:
+        """Missing required columns should raise a ``ValueError``."""
+        df = pd.DataFrame({"start_blink": [0], "foo": [1]})
+        with self.assertRaises(ValueError):
+            create_annotation(df, 30.0, "blink")
+
+    def test_invalid_sfreq_raises(self) -> None:
+        """Non-positive sampling frequency should raise a ``ValueError``."""
+        df = pd.DataFrame({"start_blink": [0], "end_blink": [1]})
+        with self.assertRaises(ValueError):
+            create_annotation(df, 0.0, "blink")
+
+    def test_invalid_label_raises(self) -> None:
+        """Non-string label should raise a ``TypeError``."""
+        df = pd.DataFrame({"start_blink": [0], "end_blink": [1]})
+        with self.assertRaises(TypeError):
+            create_annotation(df, 30.0, 1)  # type: ignore[arg-type]
+
+
+if __name__ == "__main__":  # pragma: no cover - convenience for developers
+    logging.basicConfig(level=logging.INFO)
+    unittest.main()
+


### PR DESCRIPTION
## Summary
- add typed `create_annotation` helper with detailed docstring, logging, and input checks
- cover `create_annotation` with unit tests for valid and invalid inputs

## Testing
- `pytest test/utils/test_create_annotation.py`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68c53d7ffd308325a7f9221b1b0de95b