### PR TITLE
Explicitly enumerate morphology waveform metrics

### DIFF
--- a/pyblinker/blink_features/morphology/epoch_features.py
+++ b/pyblinker/blink_features/morphology/epoch_features.py
@@ -7,10 +7,24 @@ from typing import Dict, List, Sequence
 import mne
 import pandas as pd
 
-from .per_blink import WAVEFORM_METRICS, compute_blink_waveform_metrics
+from .per_blink import compute_blink_waveform_metrics
 from ..energy.helpers import extract_blink_windows, segment_to_samples, _safe_stats
 
 logger = get_logger(__name__)
+
+# Ordered names of per-blink morphology metrics. Enumerated explicitly to
+# avoid calling ``compute_blink_waveform_metrics`` during import.
+WAVEFORM_METRICS: tuple[str, ...] = (
+    "peak_amplitude",
+    "trough_amplitude",
+    "peak_to_peak",
+    "area_abs",
+    "rise_time",
+    "fall_time",
+    "half_width",
+    "slope_rise",
+    "slope_fall",
+)
 
 # Derive metric and statistic names instead of hardcoding
 _METRICS = WAVEFORM_METRICS + ("duration",)

--- a/pyblinker/blink_features/morphology/per_blink.py
+++ b/pyblinker/blink_features/morphology/per_blink.py
@@ -80,7 +80,3 @@ def compute_blink_waveform_metrics(segment: np.ndarray, sfreq: float) -> Optiona
         "slope_rise": slope_rise,
         "slope_fall": slope_fall,
     }
-
-
-# Derive metric names for reuse elsewhere without hardcoding
-WAVEFORM_METRICS = tuple(compute_blink_waveform_metrics(np.zeros(3), 1.0).keys())

--- a/test/blink_features/utils/helpers.py
+++ b/test/blink_features/utils/helpers.py
@@ -8,7 +8,7 @@ import numpy as np
 import pandas as pd
 
 from pyblinker.blink_features.energy.helpers import _safe_stats
-from pyblinker.blink_features.morphology.per_blink import WAVEFORM_METRICS
+from pyblinker.blink_features.morphology.epoch_features import WAVEFORM_METRICS
 
 
 def assert_numeric_or_nan(testcase, values: Iterable[float]) -> None:


### PR DESCRIPTION
## Summary
- Define `WAVEFORM_METRICS` directly in `epoch_features` to avoid import-time computation and simplify morphology API
- Adjust tests to import waveform metrics from the new location

## Testing
- `pytest test/blink_features/morphology/test_epoch_morphology_features_aggregation.py -q`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68c5598c64bc8325a9507d1a72dfb0df