### PR TITLE
Remove legacy generate_blink_dataframe alias

### DIFF
--- a/pyblinker/blink_features/blink_events/__init__.py
+++ b/pyblinker/blink_features/blink_events/__init__.py
@@ -1,13 +1,9 @@
 """Blink event utilities and feature functions."""
 
-from .blink_dataframe import (
-    extract_blink_events_dataframe,
-    generate_blink_dataframe,
-)
+from .blink_dataframe import extract_blink_events_dataframe
 from .event_features import aggregate_blink_event_features
 
 __all__ = [
     "extract_blink_events_dataframe",
-    "generate_blink_dataframe",
     "aggregate_blink_event_features",
 ]

--- a/pyblinker/blink_features/blink_events/blink_dataframe.py
+++ b/pyblinker/blink_features/blink_events/blink_dataframe.py
@@ -359,7 +359,3 @@ def extract_blink_events_dataframe(
     logger.info("Extracted %d blink events", len(df))
     logger.debug("Blink events preview:\n%s", df.head())
     return df
-
-
-# Backwards compatibility
-generate_blink_dataframe = extract_blink_events_dataframe

--- a/test/blink_features/full_epoch_feature_pipeline/test_segment_raw_feature_pipeline.py
+++ b/test/blink_features/full_epoch_feature_pipeline/test_segment_raw_feature_pipeline.py
@@ -14,7 +14,7 @@ import numpy as np
 import pandas as pd
 
 from pyblinker.utils.epochs import slice_raw_into_epochs
-from pyblinker.blink_features.blink_events import generate_blink_dataframe
+from pyblinker.blink_features.blink_events import extract_blink_events_dataframe
 from pyblinker.blink_features.frequency_domain.segment_features import compute_frequency_domain_features
 from pyblinker.blink_features.energy.segment_features import compute_time_domain_features
 from pyblinker.segment_blink_properties import compute_segment_blink_properties
@@ -40,7 +40,7 @@ class TestSegmentRawFeaturePipeline(unittest.TestCase):
             raw, epoch_len=30.0, blink_label=None
         , progress_bar=False)
         self.sfreq = raw.info["sfreq"]
-        self.blink_df = generate_blink_dataframe(
+        self.blink_df = extract_blink_events_dataframe(
             self.segments, channel="EEG-E8", blink_label=None, progress_bar=False
         )
         self.params = {

--- a/test/blink_features/tutorial/test_segment_features_script.py
+++ b/test/blink_features/tutorial/test_segment_features_script.py
@@ -4,7 +4,7 @@ This test illustrates how to compute both time-domain energy and
 frequency-domain metrics for 30-second raw segments. It processes the
 bundled ``ear_eog_raw.fif`` file and extracts features for all channels whose
 names start with ``EAR``, ``EOG`` or ``EEG``. The number of blinks in each
-segment is obtained via ``generate_blink_dataframe`` and included in the
+segment is obtained via ``extract_blink_events_dataframe`` and included in the
 result. Metrics from all segments are aggregated into a ``pandas.DataFrame``
 per channel just like the original script.
 """
@@ -18,7 +18,7 @@ import pandas as pd
 from pyblinker.utils.epochs import slice_raw_into_epochs
 from pyblinker.blink_features.energy.segment_features import compute_time_domain_features
 from pyblinker.blink_features.frequency_domain.segment_features import compute_frequency_domain_features
-from pyblinker.blink_features.blink_events import generate_blink_dataframe
+from pyblinker.blink_features.blink_events import extract_blink_events_dataframe
 
 logger = logging.getLogger(__name__)
 
@@ -39,8 +39,11 @@ class TestSegmentFeaturesScript(unittest.TestCase):
         self.channels = [
             ch for ch in raw.ch_names if ch.startswith(("EAR", "EOG", "EEG"))
         ]
-        blink_channel = next((ch for ch in raw.ch_names if ch.startswith("EEG")), raw.ch_names[0])
-        blink_df = generate_blink_dataframe(
+        blink_channel = next(
+            (ch for ch in raw.ch_names if ch.startswith("EEG")),
+            raw.ch_names[0],
+        )
+        blink_df = extract_blink_events_dataframe(
             self.segments, channel=blink_channel, blink_label=None, progress_bar=False
         )
         self.blink_counts = blink_df.groupby("seg_id").size().to_dict()

--- a/test/blink_features/waveform_features/save_blink_properties_with_fit.py
+++ b/test/blink_features/waveform_features/save_blink_properties_with_fit.py
@@ -5,7 +5,7 @@ import mne
 import numpy as np
 
 from pyblinker.utils.epochs import slice_raw_into_epochs
-from pyblinker.blink_features.blink_events import generate_blink_dataframe
+from pyblinker.blink_features.blink_events import extract_blink_events_dataframe
 from pyblinker.segment_blink_properties import compute_segment_blink_properties
 
 logger = logging.getLogger(__name__)
@@ -29,7 +29,7 @@ def main():
     )
 
     # Blink dataframe
-    blink_df = generate_blink_dataframe(
+    blink_df = extract_blink_events_dataframe(
         segments,
         channel="EEG-E8",
         blink_label=None,

--- a/test/long_continous_raw/test_long_continous_raw.py
+++ b/test/long_continous_raw/test_long_continous_raw.py
@@ -14,7 +14,7 @@ import mne
 import numpy as np
 import pandas as pd
 
-from pyblinker.blink_features.blink_events import generate_blink_dataframe
+from pyblinker.blink_features.blink_events import extract_blink_events_dataframe
 from pyblinker.segment_blink_properties import (
     compute_segment_blink_properties,
 )
@@ -39,7 +39,7 @@ class TestLongContinuousRaw(unittest.TestCase):
 
         The method reads ``ear_eog_raw.fif`` from the ``test.test_files`` directory and
         stores it as a one-element list in ``self.segments``.  Blink events are
-        extracted by :func:`pyblinker.features.blink_events.generate_blink_dataframe` and the
+        extracted by :func:`pyblinker.features.blink_events.extract_blink_events_dataframe` and the
         expected total blink count is loaded from
         ``ear_eog_blink_count_epoch.csv`` which represents the epoch-based
         workflow.  A parameter dictionary for
@@ -49,7 +49,7 @@ class TestLongContinuousRaw(unittest.TestCase):
         raw_path = PROJECT_ROOT / "test" / "test_files" / "ear_eog_raw.fif"
         self.raw = mne.io.read_raw_fif(raw_path, preload=False, verbose=False)
         self.segments = [self.raw]
-        self.blink_df = generate_blink_dataframe(
+        self.blink_df = extract_blink_events_dataframe(
             self.segments, channel="EEG-E8", blink_label=None, progress_bar=False
         )
         csv_path = PROJECT_ROOT / "test" / "test_files" / "ear_eog_blink_count_epoch.csv"

--- a/test/long_continous_raw/test_long_continous_raw_with_fit.py
+++ b/test/long_continous_raw/test_long_continous_raw_with_fit.py
@@ -14,7 +14,7 @@ import mne
 import numpy as np
 import pandas as pd
 
-from pyblinker.blink_features.blink_events import generate_blink_dataframe
+from pyblinker.blink_features.blink_events import extract_blink_events_dataframe
 from pyblinker.segment_blink_properties import (
     compute_segment_blink_properties,
 )
@@ -40,7 +40,7 @@ class TestLongContinuousRawWithFit(unittest.TestCase):
 
         The method reads ``ear_eog_raw.fif`` from the ``test.test_files`` directory and
         stores it as a one-element list in ``self.segments``.  Blink events are
-        extracted by :func:`pyblinker.features.blink_events.generate_blink_dataframe` and the
+        extracted by :func:`pyblinker.features.blink_events.extract_blink_events_dataframe` and the
         expected total blink count is loaded from
         ``ear_eog_blink_count_epoch.csv`` which represents the epoch-based
         workflow.  A parameter dictionary for
@@ -50,7 +50,7 @@ class TestLongContinuousRawWithFit(unittest.TestCase):
         raw_path = PROJECT_ROOT / "test" / "test_files" / "ear_eog_raw.fif"
         self.raw = mne.io.read_raw_fif(raw_path, preload=False, verbose=False)
         self.segments = [self.raw]
-        self.blink_df = generate_blink_dataframe(
+        self.blink_df = extract_blink_events_dataframe(
             self.segments, channel="EEG-E8", blink_label=None, progress_bar=False
         )
         csv_path = PROJECT_ROOT / "test" / "test_files" / "ear_eog_blink_count_epoch.csv"


### PR DESCRIPTION
## Summary
- drop `generate_blink_dataframe` alias in blink event utilities
- update imports and tests to use `extract_blink_events_dataframe`

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c55cdaf42c8325b7868bfd99d988b8