### PR TITLE
Refactor blink window extraction

### DIFF
--- a/pyblinker/blink_features/blink_events/event_features/blink_count.py
+++ b/pyblinker/blink_features/blink_events/event_features/blink_count.py
@@ -5,6 +5,7 @@ import numpy as np
 import pandas as pd
 import mne
 from pyblinker.logging import get_logger
+from pyblinker.utils.blink_windows import extract_blink_windows
 
 from .utils import normalize_picks
 
@@ -103,65 +104,44 @@ def blink_count(
     if metadata is None:
         raise ValueError("Epochs.metadata must contain blink information")
 
-    index = metadata.index if isinstance(metadata, pd.DataFrame) else pd.RangeIndex(len(epochs))
+    if isinstance(metadata, pd.DataFrame):
+        metadata_df = metadata
+        index = metadata_df.index
+    else:
+        metadata_df = pd.DataFrame(metadata)
+        index = pd.RangeIndex(len(epochs))
+
     df = pd.DataFrame(index=index)
     df.insert(0, "ep", index.to_numpy())
 
     picks_list = normalize_picks(picks) if picks is not None else []
-    modalities: List[str] = []
-    for ch in picks_list:
-        mod = _infer_modality(ch)
-        if mod not in modalities:
-            modalities.append(mod)
-
-    def _count(entry: object) -> int:
-        if entry is None:
-            return 0
-        if isinstance(entry, (list, np.ndarray, pd.Series)):
-            arr = pd.Series(entry)
-            return int((~pd.isna(arr)).sum())
-        if pd.isna(entry):
-            return 0
-        return 1
+    rows = [row for _, row in metadata_df.iterrows()]
 
     if not picks_list:
-        onset_col = "blink_onset"
-        duration_col = "blink_duration"
-        if onset_col not in metadata or duration_col not in metadata:
-            missing = [col for col in [onset_col, duration_col] if col not in metadata]
-            raise ValueError(
-                "Epochs.metadata missing required blink columns: " + ", ".join(sorted(missing))
-            )
-        df["blink_count"] = metadata[onset_col].apply(_count).astype(float)
-        logger.debug("Blink counts per epoch: %s", df["blink_count"].tolist())
+        counts = [
+            float(len(extract_blink_windows(row, None, epoch_idx)))
+            for epoch_idx, row in enumerate(rows)
+        ]
+        df["blink_count"] = counts
+        logger.debug("Blink counts per epoch: %s", counts)
     else:
-        for modality in modalities:
-            onset_col = f"blink_onset_{modality}"
-            duration_col = f"blink_duration_{modality}"
-            if onset_col not in metadata or duration_col not in metadata:
-                logger.debug(
-                    "Modality '%s' missing specific columns; using generic blink columns",
-                    modality,
-                )
-                onset_col = "blink_onset"
-                duration_col = "blink_duration"
-                if onset_col not in metadata or duration_col not in metadata:
-                    missing = [
-                        col
-                        for col in [onset_col, duration_col]
-                        if col not in metadata
-                    ]
-                    raise ValueError(
-                        "Epochs.metadata missing required blink columns: "
-                        + ", ".join(sorted(missing))
-                    )
+        mod_to_channel: Dict[str, str] = {}
+        for ch in picks_list:
+            mod = _infer_modality(ch)
+            if mod not in mod_to_channel:
+                mod_to_channel[mod] = ch
 
+        for modality, channel in mod_to_channel.items():
+            counts = [
+                float(len(extract_blink_windows(row, channel, epoch_idx)))
+                for epoch_idx, row in enumerate(rows)
+            ]
             col_name = f"blink_count_{modality}"
-            df[col_name] = metadata[onset_col].apply(_count).astype(float)
+            df[col_name] = counts
             logger.debug(
                 "Blink counts for modality '%s': %s",
                 modality,
-                df[col_name].tolist(),
+                counts,
             )
 
     logger.info("Finished counting blinks")

--- a/pyblinker/blink_features/blink_events/event_features/inter_blink_interval.py
+++ b/pyblinker/blink_features/blink_events/event_features/inter_blink_interval.py
@@ -1,10 +1,12 @@
 """Inter-blink interval based features."""
-from typing import Dict, List, Sequence, Iterable
+from typing import Dict, List, Sequence, Iterable, Tuple
 from pyblinker.logging import get_logger
 
 import numpy as np
 import pandas as pd
 import mne
+
+from pyblinker.utils.blink_windows import extract_blink_windows
 
 from .utils import normalize_picks, require_channels
 
@@ -145,9 +147,22 @@ def compute_ibi_features(blinks: List[Dict[str, int]], sfreq: float) -> Dict[str
     }
 
 
-def _infer_modality(channel: str) -> str:
-    """Infer modality label (e.g., ``"eeg"``) from a channel name."""
-    return channel.split("-", 1)[0].lower()
+def _mean_inter_blink_interval(windows: Sequence[Tuple[float, float]]) -> float:
+    """Return the mean interval separating successive blink windows."""
+
+    if len(windows) < 2:
+        return float("nan")
+
+    starts = np.asarray([onset for onset, _ in windows], dtype=float)
+    durations = np.asarray([duration for _, duration in windows], dtype=float)
+    order = np.argsort(starts)
+    starts = starts[order]
+    durations = durations[order]
+    ends = starts + durations
+    intervals = starts[1:] - ends[:-1]
+    if intervals.size == 0:
+        return float("nan")
+    return float(np.mean(intervals))
 
 
 def inter_blink_interval_epochs(
@@ -198,11 +213,17 @@ def inter_blink_interval_epochs(
     if metadata is None:
         raise ValueError("Epochs.metadata must contain blink information")
 
-    index = (
-        metadata.index if isinstance(metadata, pd.DataFrame) else pd.RangeIndex(len(epochs))
-    )
+    if isinstance(metadata, pd.DataFrame):
+        metadata_df = metadata
+        index = metadata_df.index
+    else:
+        metadata_df = pd.DataFrame(metadata)
+        index = pd.RangeIndex(len(epochs))
+
     df = pd.DataFrame(index=index)
     df.insert(0, "ep", index.to_numpy())
+
+    rows = [row for _, row in metadata_df.iterrows()]
 
     logger.info(
         "Computing inter-blink intervals for %d epochs and channels %s",
@@ -211,82 +232,19 @@ def inter_blink_interval_epochs(
     )
 
     if not picks_list:
-        onset_col = "blink_onset"
-        duration_col = "blink_duration"
-        if onset_col not in metadata or duration_col not in metadata:
-            missing = [col for col in [onset_col, duration_col] if col not in metadata]
-            raise ValueError(
-                "Epochs.metadata missing required blink columns: "
-                + ", ".join(sorted(missing))
-            )
-        ibis: List[float] = []
-        for onset, duration in zip(metadata[onset_col], metadata[duration_col]):
-            onsets = (
-                onset
-                if isinstance(onset, list)
-                else ([] if onset is None or pd.isna(onset) else [float(onset)])
-            )
-            durations = (
-                duration
-                if isinstance(duration, list)
-                else ([] if duration is None or pd.isna(duration) else [float(duration)])
-            )
-            if len(onsets) < 2:
-                ibis.append(float("nan"))
-                continue
-            ends = [o + d for o, d in zip(onsets, durations)]
-            intervals = [onsets[i + 1] - ends[i] for i in range(len(onsets) - 1)]
-            ibis.append(float(np.mean(intervals)) if intervals else float("nan"))
+        ibis = [
+            _mean_inter_blink_interval(extract_blink_windows(row, None, epoch_idx))
+            for epoch_idx, row in enumerate(rows)
+        ]
         df["ibi"] = ibis
     else:
         for ch in picks_list:
-            modality = _infer_modality(ch)
-            onset_col = f"blink_onset_{modality}"
-            duration_col = f"blink_duration_{modality}"
-            if onset_col not in metadata or duration_col not in metadata:
-                logger.debug(
-                    "Falling back to generic blink columns for channel %s", ch
-                )
-                onset_col = "blink_onset"
-                duration_col = "blink_duration"
-            else:
-                logger.debug(
-                    "Using modality-specific columns '%s' and '%s' for channel %s",
-                    onset_col,
-                    duration_col,
-                    ch,
-                )
-            if onset_col not in metadata or duration_col not in metadata:
-                missing = [
-                    col
-                    for col in [onset_col, duration_col]
-                    if col not in metadata
-                ]
-                raise ValueError(
-                    "Epochs.metadata missing required blink columns: "
-                    + ", ".join(sorted(missing))
-                )
-
-            ibis: List[float] = []
-            for onset, duration in zip(metadata[onset_col], metadata[duration_col]):
-                onsets = (
-                    onset
-                    if isinstance(onset, list)
-                    else ([] if onset is None or pd.isna(onset) else [float(onset)])
-                )
-                durations = (
-                    duration
-                    if isinstance(duration, list)
-                    else ([] if duration is None or pd.isna(duration) else [float(duration)])
-                )
-                if len(onsets) < 2:
-                    ibis.append(float("nan"))
-                    continue
-                ends = [o + d for o, d in zip(onsets, durations)]
-                intervals = [onsets[i + 1] - ends[i] for i in range(len(onsets) - 1)]
-                ibis.append(float(np.mean(intervals)) if intervals else float("nan"))
-
+            ibis = [
+                _mean_inter_blink_interval(extract_blink_windows(row, ch, epoch_idx))
+                for epoch_idx, row in enumerate(rows)
+            ]
             df[f"ibi_{ch}"] = ibis
+            logger.debug("IBI values for channel '%s': %s", ch, ibis)
 
     logger.debug("Computed channel-wise IBI DataFrame shape: %s", df.shape)
     logger.info("Finished computing IBI DataFrame")

--- a/pyblinker/blink_features/energy/helpers.py
+++ b/pyblinker/blink_features/energy/helpers.py
@@ -5,101 +5,16 @@ calculations. They operate on :class:`pandas.Series` metadata rows and
 NumPy arrays representing eyelid aperture signals.
 """
 from __future__ import annotations
-from pyblinker.logging import get_logger
 
-from typing import Dict, List, Sequence, Tuple
-import ast
+from typing import Dict, Sequence
 
 import numpy as np
-import pandas as pd
+
+from pyblinker.logging import get_logger
+from pyblinker.utils.blink_windows import extract_blink_windows
+
 
 logger = get_logger(__name__)
-
-
-def extract_blink_windows(
-    metadata_row: pd.Series, channel: str, epoch_index: int
-) -> List[Tuple[float, float]]:
-    """Extract blink onset and duration pairs from an epoch's metadata.
-
-    The modality (``eeg``, ``eog`` or ``ear``) is inferred from ``channel``
-    and used to select modality-specific metadata columns. If those columns
-    are missing or empty, the generic ``blink_onset``/``blink_duration``
-    entries are used instead. When neither modality-specific nor generic
-    keys are present, a :class:`ValueError` is raised.
-
-    Parameters
-    ----------
-    metadata_row : pandas.Series
-        A single row from ``epochs.metadata``. Entries may be scalars, lists or
-        string representations thereof.
-    channel : str
-        Channel name used to infer the modality.
-    epoch_index : int
-        Index of the epoch within ``epochs``. Included in error messages.
-
-    Returns
-    -------
-    list of tuple of float
-        List of ``(onset_seconds, duration_seconds)`` pairs. An empty list
-        is returned when no blinks are present.
-
-    Raises
-    ------
-    ValueError
-        If neither modality-specific nor generic onset/duration metadata
-        exist for the provided epoch.
-    """
-
-    logger.info("Entering extract_blink_windows")
-
-    ch_lower = channel.lower()
-    if "ear" in ch_lower:
-        mod = "ear"
-    elif "eog" in ch_lower:
-        mod = "eog"
-    else:
-        mod = "eeg"
-
-    mod_onset_key = f"blink_onset_{mod}"
-    mod_duration_key = f"blink_duration_{mod}"
-
-    def _is_missing(val: object) -> bool:
-        return val is None or (isinstance(val, float) and np.isnan(val))
-
-    has_mod_keys = mod_onset_key in metadata_row and mod_duration_key in metadata_row
-    if has_mod_keys:
-        onsets = metadata_row.get(mod_onset_key)
-        durations = metadata_row.get(mod_duration_key)
-        if _is_missing(onsets) or _is_missing(durations):
-            return []
-    else:
-        onsets = metadata_row.get("blink_onset")
-        durations = metadata_row.get("blink_duration")
-
-
-
-    def _ensure_list(val: object) -> List[object]:
-        """Coerce scalar or string representations into a list."""
-        if isinstance(val, str):
-            try:
-                val = ast.literal_eval(val)
-            except (SyntaxError, ValueError):
-                pass
-        if isinstance(val, (list, tuple, np.ndarray, pd.Series)):
-            return list(val)
-        return [val]
-
-    onsets = _ensure_list(onsets)
-    durations = _ensure_list(durations)
-
-    windows: List[Tuple[float, float]] = []
-    for onset, duration in zip(onsets, durations):
-        if _is_missing(onset) or _is_missing(duration):
-            continue
-        windows.append((float(onset), float(duration)))
-    logger.debug("Extracted %d blink windows", len(windows))
-    logger.info("Exiting extract_blink_windows")
-    return windows
 
 
 def segment_to_samples(onset_s: float, duration_s: float, sfreq: float, n_times: int) -> slice:
@@ -165,3 +80,5 @@ def _tkeo(x: np.ndarray) -> np.ndarray:
     if x.size >= 3:
         psi[1:-1] = x[1:-1] ** 2 - x[:-2] * x[2:]
     return psi
+
+__all__ = ["extract_blink_windows", "segment_to_samples", "_safe_stats", "_tkeo"]

--- a/pyblinker/utils/blink_windows.py
+++ b/pyblinker/utils/blink_windows.py
@@ -1,0 +1,147 @@
+"""Utilities for working with blink onset and duration metadata."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import List, Tuple
+
+import ast
+import numpy as np
+import pandas as pd
+
+from pyblinker.logging import get_logger
+
+
+logger = get_logger(__name__)
+
+
+def _contains(metadata_row: pd.Series | Mapping[str, object], key: str) -> bool:
+    """Return ``True`` when ``key`` is available in ``metadata_row``."""
+    if isinstance(metadata_row, pd.Series):
+        return key in metadata_row.index
+    return key in metadata_row
+
+
+def extract_blink_windows(
+    metadata_row: pd.Series | Mapping[str, object],
+    channel: str | None,
+    epoch_index: int,
+) -> List[Tuple[float, float]]:
+    """Extract blink onset/duration pairs for a single epoch.
+
+    Parameters
+    ----------
+    metadata_row
+        Row from ``epochs.metadata`` providing blink annotations. Values may be
+        scalars, lists, or string representations of lists.
+    channel
+        Channel name used to infer the modality-specific metadata columns. If
+        set to ``None`` or a generic sentinel (``"generic"``, ``"all"`` or
+        ``"any"``), the function bypasses modality-specific columns and
+        directly consults ``blink_onset``/``blink_duration``.
+    epoch_index
+        Integer position of the epoch in ``epochs``. Included in error logs to
+        aid debugging.
+
+    Returns
+    -------
+    list of tuple of float
+        Sequence of ``(onset_seconds, duration_seconds)`` pairs. An empty list
+        is returned when no blinks are recorded.
+
+    Raises
+    ------
+    ValueError
+        If neither modality-specific nor generic blink metadata columns are
+        available for the requested channel.
+    TypeError
+        If ``metadata_row`` is not a :class:`pandas.Series` or mapping.
+    """
+
+    channel_label = channel if channel is not None else "generic"
+    logger.info(
+        "Entering extract_blink_windows for channel %s (epoch %d)",
+        channel_label,
+        epoch_index,
+    )
+
+    if not isinstance(metadata_row, (pd.Series, Mapping)):
+        logger.error("Unsupported metadata row type: %s", type(metadata_row))
+        raise TypeError("metadata_row must be a pandas.Series or mapping")
+
+    ch_lower = channel_label.lower()
+    prefer_generic = ch_lower in {"generic", "all", "any", ""}
+    if "ear" in ch_lower:
+        mod = "ear"
+    elif "eog" in ch_lower:
+        mod = "eog"
+    else:
+        mod = "eeg"
+
+    mod_onset_key = f"blink_onset_{mod}"
+    mod_duration_key = f"blink_duration_{mod}"
+
+    def _is_missing(val: object) -> bool:
+        return val is None or (isinstance(val, float) and np.isnan(val))
+
+    if (not prefer_generic) and _contains(metadata_row, mod_onset_key) and _contains(
+        metadata_row, mod_duration_key
+    ):
+        onsets = metadata_row.get(mod_onset_key)
+        durations = metadata_row.get(mod_duration_key)
+        if _is_missing(onsets) or _is_missing(durations):
+            logger.debug(
+                "Modality-specific metadata for channel %s contains missing values",
+                channel_label,
+            )
+            windows: List[Tuple[float, float]] = []
+            logger.info("Exiting extract_blink_windows")
+            return windows
+    else:
+        generic_keys = ("blink_onset", "blink_duration")
+        missing = [key for key in generic_keys if not _contains(metadata_row, key)]
+        if missing:
+            logger.error("Missing blink metadata columns: %s", ", ".join(sorted(missing)))
+            raise ValueError(
+                "Epochs.metadata missing required blink columns: "
+                + ", ".join(sorted(missing))
+            )
+        onsets = metadata_row.get("blink_onset")
+        durations = metadata_row.get("blink_duration")
+        if _is_missing(onsets) or _is_missing(durations):
+            logger.debug(
+                "Generic metadata contains missing values for channel %s",
+                channel_label,
+            )
+            windows = []
+            logger.info("Exiting extract_blink_windows")
+            return windows
+
+    def _ensure_list(val: object) -> List[object]:
+        """Coerce scalars or string encodings of lists to ``list`` objects."""
+
+        if isinstance(val, str):
+            try:
+                val = ast.literal_eval(val)
+            except (SyntaxError, ValueError):
+                pass
+        if isinstance(val, (list, tuple, np.ndarray, pd.Series)):
+            return list(val)
+        return [val]
+
+    onsets_list = _ensure_list(onsets)
+    durations_list = _ensure_list(durations)
+
+    windows = []
+    for onset, duration in zip(onsets_list, durations_list):
+        if _is_missing(onset) or _is_missing(duration):
+            continue
+        windows.append((float(onset), float(duration)))
+
+    logger.debug("Extracted %d blink windows", len(windows))
+    logger.info("Exiting extract_blink_windows")
+    return windows
+
+
+__all__ = ["extract_blink_windows"]
+


### PR DESCRIPTION
## Summary
- move `extract_blink_windows` into `pyblinker/utils/blink_windows.py` and re-export it from the energy helpers module
- update blink count and inter-blink interval features to collect blink windows through the shared helper and derive their metrics from those windows
- adjust aggregation logic to work with the shared window list approach

## Testing
- pytest test/blink_features/blink_events/test_blink_count.py
- pytest test/blink_features/blink_events/test_inter_blink_interval.py
- ruff check .

------
https://chatgpt.com/codex/tasks/task_e_68c92429d38c8325861e5cd8c2d97516