### PR TITLE
Refactor modality inference into shared utility

### DIFF
--- a/pyblinker/blink_features/blink_events/event_features/blink_count.py
+++ b/pyblinker/blink_features/blink_events/event_features/blink_count.py
@@ -5,6 +5,7 @@ import numpy as np
 import pandas as pd
 import mne
 from pyblinker.logging import get_logger
+from pyblinker.utils.modality import infer_modality
 
 from .utils import normalize_picks
 
@@ -59,13 +60,6 @@ def blink_count_epoch(
     else:
         logger.error("Unsupported type passed to blink_count_epoch: %s", type(blinks))
         raise TypeError(f"Unsupported input type: {type(blinks)}")
-
-
-def _infer_modality(channel: str) -> str:
-    """Infer modality label (e.g., ``"eeg"``) from a channel name."""
-    return channel.split("-", 1)[0].lower()
-
-
 def blink_count(
     epochs: mne.Epochs, picks: str | Iterable[str] | None = None
 ) -> pd.DataFrame:
@@ -110,7 +104,7 @@ def blink_count(
     picks_list = normalize_picks(picks) if picks is not None else []
     modalities: List[str] = []
     for ch in picks_list:
-        mod = _infer_modality(ch)
+        mod = infer_modality(ch)
         if mod not in modalities:
             modalities.append(mod)
 

--- a/pyblinker/blink_features/blink_events/event_features/inter_blink_interval.py
+++ b/pyblinker/blink_features/blink_events/event_features/inter_blink_interval.py
@@ -1,6 +1,7 @@
 """Inter-blink interval based features."""
 from typing import Dict, List, Sequence, Iterable
 from pyblinker.logging import get_logger
+from pyblinker.utils.modality import infer_modality
 
 import numpy as np
 import pandas as pd
@@ -143,13 +144,6 @@ def compute_ibi_features(blinks: List[Dict[str, int]], sfreq: float) -> Dict[str
         "ibi_permutation_entropy": pe,
         "ibi_hurst_exponent": hurst,
     }
-
-
-def _infer_modality(channel: str) -> str:
-    """Infer modality label (e.g., ``"eeg"``) from a channel name."""
-    return channel.split("-", 1)[0].lower()
-
-
 def inter_blink_interval_epochs(
     epochs: mne.Epochs, picks: str | Iterable[str] | None = None
 ) -> pd.DataFrame:
@@ -240,7 +234,7 @@ def inter_blink_interval_epochs(
         df["ibi"] = ibis
     else:
         for ch in picks_list:
-            modality = _infer_modality(ch)
+            modality = infer_modality(ch)
             onset_col = f"blink_onset_{modality}"
             duration_col = f"blink_duration_{modality}"
             if onset_col not in metadata or duration_col not in metadata:

--- a/pyblinker/segment_blink_properties.py
+++ b/pyblinker/segment_blink_properties.py
@@ -27,6 +27,7 @@ from .utils.blink_metadata import (
     attach_blink_metadata,
     _sample_windows_from_metadata,
 )
+from .utils.modality import infer_modality
 
 from .blinker.fit_blink import FitBlinks
 from .blink_features.waveform_features.extract_blink_properties import BlinkProperties
@@ -139,7 +140,7 @@ def compute_from_refined_epochs(
     for ei, ci, ch in iterator:
         metadata_row = safe_metadata_row(epochs.metadata, ei)
         signal = data[ei, ci]
-        mod = infer_modality_from_channel(ch)
+        mod = infer_modality(ch)
 
         sample_windows = _sample_windows_from_metadata(
             metadata_row, ch, sfreq, n_times, ei
@@ -232,7 +233,7 @@ def compute_from_raw_segments(
             signal = raw.get_data(picks=ch)[0]
             rows = seg_rows.copy()
             rows["channel"] = ch
-            rows["modality"] = infer_modality_from_channel(ch)
+            rows["modality"] = infer_modality(ch)
             props = fit_and_extract_properties(signal, rows, sfreq, params, run_fit)
             if props is None or props.empty:
                 continue
@@ -270,18 +271,6 @@ def build_epoch_channel_tasks(
 def safe_metadata_row(metadata: pd.DataFrame | None, ei: int) -> pd.Series:
     """Safely access a metadata row; return empty Series if metadata is ``None``."""
     return metadata.iloc[ei] if isinstance(metadata, pd.DataFrame) else pd.Series(dtype=float)
-
-
-def infer_modality_from_channel(ch_name: str) -> str:
-    """Infer modality label (``'eeg'``, ``'eog'``, or ``'ear'``) from a channel name."""
-    lower = ch_name.lower()
-    if "eeg" in lower:
-        return "eeg"
-    if "eog" in lower:
-        return "eog"
-    return "ear"
-
-
 def build_candidate_rows_for_epoch_channel(
     signal: np.ndarray,
     sample_windows: Sequence[slice],

--- a/pyblinker/utils/__init__.py
+++ b/pyblinker/utils/__init__.py
@@ -18,6 +18,7 @@ from .raw_preprocessing import prepare_refined_segments
 from .misc import create_annotation
 from .blink_metadata import onset_entry_to_blinks
 from .report import add_blink_plots_to_report
+from .modality import infer_modality
 
 __all__ = [
     "slice_raw_to_segments",
@@ -35,4 +36,5 @@ __all__ = [
     "create_annotation",
     "onset_entry_to_blinks",
     "add_blink_plots_to_report",
+    "infer_modality",
 ]

--- a/pyblinker/utils/modality.py
+++ b/pyblinker/utils/modality.py
@@ -1,0 +1,38 @@
+"""Utilities for inferring signal modality from channel names."""
+
+from __future__ import annotations
+
+
+def infer_modality(channel_name: str) -> str:
+    """Infer the modality label for a recording channel.
+
+    Parameters
+    ----------
+    channel_name : str
+        Channel name whose modality should be determined.
+
+    Returns
+    -------
+    str
+        Lowercase modality label derived from the channel name. Known
+        modality keywords (``"eeg"``, ``"eog"``, ``"ear"``) are prioritised.
+        When the channel name contains a hyphen, the substring preceding the
+        first hyphen is returned if present. If no keywords or separator are
+        present the channel name itself (lowercased) is returned.
+    """
+
+    cleaned = channel_name.strip()
+    if not cleaned:
+        return ""
+
+    if "-" in cleaned:
+        prefix = cleaned.split("-", 1)[0].strip().lower()
+        if prefix:
+            return prefix
+
+    lower_name = cleaned.lower()
+    for keyword in ("eeg", "eog", "ear"):
+        if keyword in lower_name:
+            return keyword
+
+    return lower_name

--- a/test/utils/test_modality.py
+++ b/test/utils/test_modality.py
@@ -1,0 +1,37 @@
+"""Unit tests for channel modality inference helpers."""
+
+import unittest
+
+from pyblinker.utils.modality import infer_modality
+
+
+class TestInferModality(unittest.TestCase):
+    """Validate the ``infer_modality`` utility function."""
+
+    def test_prefix_based_inference(self) -> None:
+        """Channels with hyphen prefixes resolve to the prefix label."""
+
+        self.assertEqual(infer_modality("EEG-E8"), "eeg")
+        self.assertEqual(infer_modality("EOG-EEG-eog_vert_left"), "eog")
+        self.assertEqual(infer_modality("EAR-Left"), "ear")
+
+    def test_keyword_detection_without_separator(self) -> None:
+        """Keyword lookup handles channels without separators."""
+
+        self.assertEqual(infer_modality("EEG001"), "eeg")
+        self.assertEqual(infer_modality("earclip"), "ear")
+
+    def test_fallback_lowercase(self) -> None:
+        """Unknown channel names are lowercased as a fallback."""
+
+        self.assertEqual(infer_modality("Fp1"), "fp1")
+
+    def test_handles_whitespace_and_empty(self) -> None:
+        """Whitespace is ignored and empty names produce an empty string."""
+
+        self.assertEqual(infer_modality("  EEG-E8  "), "eeg")
+        self.assertEqual(infer_modality(""), "")
+
+
+if __name__ == "__main__":  # pragma: no cover - convenience
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a dedicated utils.modality module that exposes infer_modality
- reuse the shared helper inside blink count, IBI, and segment property code
- export the helper via utils.__init__ and cover behaviour with a new unit test

## Testing
- pytest test/utils/test_modality.py
- pytest test/blink_features/blink_events/test_blink_count.py
- pytest test/blink_features/blink_events/test_inter_blink_interval.py
- pytest test/blink_features/waveform_features/test_segment_blink_properties.py
- ruff check .

------
https://chatgpt.com/codex/tasks/task_e_68c9245788048325b87bf0ab13be0877