### PR TITLE
Use shared mad helper in baseline MAD feature

### DIFF
--- a/pyblinker/blink_features/open_eye/features/baseline_mad.py
+++ b/pyblinker/blink_features/open_eye/features/baseline_mad.py
@@ -1,6 +1,7 @@
 """Median absolute deviation of open-eye baseline."""
 from typing import List, Dict
 import numpy as np
+from pyblinker.fitutils import mad
 from pyblinker.logging import get_logger
 
 logger = get_logger(__name__)
@@ -14,7 +15,6 @@ def baseline_mad_epoch(epoch_signal: np.ndarray, blinks: List[Dict[str, int]]) -
     open_signal = epoch_signal[mask]
     if open_signal.size == 0:
         return float("nan")
-    median = np.median(open_signal)
-    mad = float(np.median(np.abs(open_signal - median)))
-    logger.debug("Baseline MAD: %s", mad)
-    return mad
+    mad_value = float(mad(open_signal))
+    logger.debug("Baseline MAD: %s", mad_value)
+    return mad_value


### PR DESCRIPTION
## Summary
- import the shared `mad` utility for baseline MAD feature calculation
- reuse the centralized MAD implementation instead of recomputing locally

## Testing
- pytest
- ruff check .

------
https://chatgpt.com/codex/tasks/task_e_68c9247cd0e48325a4e2ed1376e6782d