### PR TITLE
Centralize average velocity helper

### DIFF
--- a/pyblinker/blinker/zero_crossing.py
+++ b/pyblinker/blinker/zero_crossing.py
@@ -20,16 +20,6 @@ def get_line_intersection_slope(
     return left_slope, right_slope
 
 
-def get_average_velocity(p_left, p_right, x_left, x_right):
-    """
-    Original logic retained. Computes average velocities.
-    """
-    # Using local references is possible, but it's already short.
-    aver_left_velocity = p_left.coef[1] / np.std(x_left)
-    aver_right_velocity = p_right.coef[1] / np.std(x_right)
-    return aver_left_velocity, aver_right_velocity
-
-
 def left_right_zero_crossing(
     candidate_signal: np.ndarray,
     max_blink: float,

--- a/pyblinker/fitutils/line_intersection.py
+++ b/pyblinker/fitutils/line_intersection.py
@@ -12,6 +12,7 @@ from pyblinker.fitutils.forking import (
     get_intersection,
 )
 from pyblinker.blinker.zero_crossing import get_line_intersection_slope
+from pyblinker.utils.velocity import average_velocity
 
 
 def lines_intersection(
@@ -71,8 +72,8 @@ def lines_intersection(
         x_intersect, y_intersect, left_x_intercept, right_x_intercept
     )
 
-    aver_left_velocity = p_left[0] / mu_left[1]
-    aver_right_velocity = p_right[0] / mu_right[1]
+    aver_left_velocity = average_velocity(p_left, x_scale=mu_left[1])
+    aver_right_velocity = average_velocity(p_right, x_scale=mu_right[1])
 
     return (
         left_slope,

--- a/pyblinker/utils/velocity.py
+++ b/pyblinker/utils/velocity.py
@@ -1,0 +1,102 @@
+"""Helper utilities for velocity calculations."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Protocol, runtime_checkable
+
+import numpy as np
+from numpy.typing import ArrayLike
+
+from pyblinker.logging import get_logger
+
+
+logger = get_logger(__name__)
+
+
+@runtime_checkable
+class SupportsCoef(Protocol):
+    """Protocol describing polynomial-like objects exposing ``coef``."""
+
+    @property
+    def coef(self) -> Sequence[float]:
+        """Return polynomial coefficients ordered by degree."""
+
+
+CoefficientLike = SupportsCoef | Sequence[float] | np.ndarray
+
+
+def _extract_linear_slope(coefficients: CoefficientLike) -> float:
+    """Return the slope component from ``coefficients``.
+
+    Args:
+        coefficients: Linear polynomial description supporting either the
+            :class:`SupportsCoef` protocol or representing the coefficients
+            directly as a one-dimensional sequence.
+
+    Returns:
+        The slope (first-order coefficient) as a floating-point value.
+
+    Raises:
+        ValueError: If ``coefficients`` lacks a linear term or is empty.
+    """
+
+    if isinstance(coefficients, SupportsCoef):
+        coef_array = np.asarray(coefficients.coef, dtype=float)
+        if coef_array.size < 2:
+            msg = "Coefficients must include a linear term to compute velocity."
+            logger.error(msg)
+            raise ValueError(msg)
+        return float(coef_array[1])
+
+    coef_array = np.asarray(coefficients, dtype=float).ravel()
+    if coef_array.size == 0:
+        msg = "Coefficient sequence must not be empty."
+        logger.error(msg)
+        raise ValueError(msg)
+    return float(coef_array[0])
+
+
+def average_velocity(
+    coefficients: CoefficientLike,
+    *,
+    x_values: ArrayLike | None = None,
+    x_scale: float | None = None,
+) -> float:
+    """Compute the average velocity associated with a linear fit.
+
+    Args:
+        coefficients: Linear polynomial coefficients or objects exposing a
+            ``coef`` attribute in the style of :class:`numpy.polynomial.Polynomial`.
+        x_values: Optional x coordinates used to create the linear fit. When
+            provided, the population standard deviation of ``x_values`` becomes
+            the scaling factor.
+        x_scale: Optional pre-computed scaling factor (for example the standard
+            deviation returned by MATLAB's ``polyfit`` implementation).
+
+    Returns:
+        The average velocity defined as the slope divided by the relevant x-axis
+        scaling factor.
+
+    Raises:
+        ValueError: If neither ``x_values`` nor ``x_scale`` are provided, or if
+            the coefficient input does not expose a linear term.
+    """
+
+    if x_scale is None:
+        if x_values is None:
+            msg = "Either 'x_values' or 'x_scale' must be provided."
+            logger.error(msg)
+            raise ValueError(msg)
+        x_array = np.asarray(x_values, dtype=float)
+        if x_array.size == 0:
+            msg = "'x_values' must contain at least one element."
+            logger.error(msg)
+            raise ValueError(msg)
+        x_scale = float(np.std(x_array))
+
+    slope = _extract_linear_slope(coefficients)
+    return float(slope / x_scale)
+
+
+__all__ = ["average_velocity"]


### PR DESCRIPTION
## Summary
- add `utils.velocity.average_velocity` to centralize the blink average velocity calculation
- update `fitutils.line_intersection` to use the shared helper
- drop the redundant `blinker.zero_crossing.get_average_velocity` implementation

## Testing
- pytest test/blink_features/pyblinker/test_blink_features.py::test_lines_intersection_first_two
- ruff check .

------
https://chatgpt.com/codex/tasks/task_e_68c9249a20308325ab8439b4a89fd2a7