### PR TITLE
Add shared modality inference utility

### DIFF
--- a/pyblinker/blink_features/blink_events/event_features/blink_count.py
+++ b/pyblinker/blink_features/blink_events/event_features/blink_count.py
@@ -8,6 +8,7 @@ from pyblinker.logging import get_logger
 from pyblinker.utils.blink_windows import extract_blink_windows
 
 from pyblinker.utils import normalize_picks
+from pyblinker.utils.modality import infer_modality
 
 
 logger = get_logger(__name__)
@@ -60,11 +61,6 @@ def blink_count_epoch(
     else:
         logger.error("Unsupported type passed to blink_count_epoch: %s", type(blinks))
         raise TypeError(f"Unsupported input type: {type(blinks)}")
-
-
-def _infer_modality(channel: str) -> str:
-    """Infer modality label (e.g., ``"eeg"``) from a channel name."""
-    return channel.split("-", 1)[0].lower()
 
 
 def blink_count(
@@ -127,7 +123,7 @@ def blink_count(
     else:
         mod_to_channel: Dict[str, str] = {}
         for ch in picks_list:
-            mod = _infer_modality(ch)
+            mod = infer_modality(ch)
             if mod not in mod_to_channel:
                 mod_to_channel[mod] = ch
 

--- a/pyblinker/blink_features/blink_events/event_features/inter_blink_interval.py
+++ b/pyblinker/blink_features/blink_events/event_features/inter_blink_interval.py
@@ -9,6 +9,7 @@ import mne
 from pyblinker.utils.blink_windows import extract_blink_windows
 
 from pyblinker.utils import normalize_picks, require_channels
+from pyblinker.utils.modality import infer_modality
 
 logger = get_logger(__name__)
 
@@ -239,12 +240,13 @@ def inter_blink_interval_epochs(
         df["ibi"] = ibis
     else:
         for ch in picks_list:
+            modality = infer_modality(ch)
             ibis = [
                 _mean_inter_blink_interval(extract_blink_windows(row, ch, epoch_idx))
                 for epoch_idx, row in enumerate(rows)
             ]
             df[f"ibi_{ch}"] = ibis
-            logger.debug("IBI values for channel '%s': %s", ch, ibis)
+            logger.debug("IBI values for channel '%s' (modality '%s'): %s", ch, modality, ibis)
 
     logger.debug("Computed channel-wise IBI DataFrame shape: %s", df.shape)
     logger.info("Finished computing IBI DataFrame")

--- a/pyblinker/segment_blink_properties.py
+++ b/pyblinker/segment_blink_properties.py
@@ -31,6 +31,7 @@ from .utils.blink_metadata import (
 from .blinker.fit_blink import FitBlinks
 from .blink_features.waveform_features.extract_blink_properties import BlinkProperties
 from .utils import normalize_picks, require_channels
+from .utils.modality import infer_modality
 from .blinker.zero_crossing import left_right_zero_crossing
 
 logger = get_logger(__name__)
@@ -142,7 +143,7 @@ def compute_from_refined_epochs(
     for ei, ci, ch in iterator:
         metadata_row = safe_metadata_row(epochs.metadata, ei)
         signal = data[ei, ci]
-        mod = infer_modality_from_channel(ch)
+        mod = infer_modality(ch)
 
         sample_windows = _sample_windows_from_metadata(
             metadata_row, ch, sfreq, n_times, ei
@@ -235,7 +236,7 @@ def compute_from_raw_segments(
             signal = raw.get_data(picks=ch)[0]
             rows = seg_rows.copy()
             rows["channel"] = ch
-            rows["modality"] = infer_modality_from_channel(ch)
+            rows["modality"] = infer_modality(ch)
             props = fit_and_extract_properties(signal, rows, sfreq, params, run_fit)
             if props is None or props.empty:
                 continue
@@ -259,16 +260,6 @@ def build_epoch_channel_tasks(
 def safe_metadata_row(metadata: pd.DataFrame | None, ei: int) -> pd.Series:
     """Safely access a metadata row; return empty Series if metadata is ``None``."""
     return metadata.iloc[ei] if isinstance(metadata, pd.DataFrame) else pd.Series(dtype=float)
-
-
-def infer_modality_from_channel(ch_name: str) -> str:
-    """Infer modality label (``'eeg'``, ``'eog'``, or ``'ear'``) from a channel name."""
-    lower = ch_name.lower()
-    if "eeg" in lower:
-        return "eeg"
-    if "eog" in lower:
-        return "eog"
-    return "ear"
 
 
 def build_candidate_rows_for_epoch_channel(

--- a/pyblinker/utils/__init__.py
+++ b/pyblinker/utils/__init__.py
@@ -19,6 +19,7 @@ from .misc import create_annotation
 from .blink_metadata import onset_entry_to_blinks
 from .report import add_blink_plots_to_report
 from .channel_utils import normalize_picks, require_channels
+from .modality import infer_modality
 
 __all__ = [
     "slice_raw_to_segments",
@@ -38,4 +39,5 @@ __all__ = [
     "add_blink_plots_to_report",
     "normalize_picks",
     "require_channels",
+    "infer_modality",
 ]

--- a/pyblinker/utils/modality.py
+++ b/pyblinker/utils/modality.py
@@ -1,0 +1,52 @@
+"""Utilities for inferring channel modalities."""
+
+from __future__ import annotations
+
+from pyblinker.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+def infer_modality(channel_name: str) -> str:
+    """Infer a modality label from a channel name.
+
+    Parameters
+    ----------
+    channel_name : str
+        Channel identifier from which the modality should be derived.
+
+    Returns
+    -------
+    str
+        Lowercase modality string. Known substrings such as ``"eeg"``,
+        ``"eog"``, and ``"ear"`` take precedence. If none of these are found,
+        the function falls back to the channel prefix before the first hyphen.
+    """
+    logger.debug("Inferring modality from channel name: %s", channel_name)
+
+    lower_name = channel_name.lower().strip()
+    if "-" in channel_name:
+        prefix = lower_name.split("-", 1)[0]
+        if prefix in {"eeg", "eog", "ear"}:
+            logger.debug(
+                "Detected modality '%s' based on channel prefix in '%s'", prefix, channel_name
+            )
+            return prefix
+    for candidate in ("ear", "eog", "eeg"):
+        if candidate in lower_name:
+            logger.debug(
+                "Detected modality '%s' based on substring match in '%s'", candidate, channel_name
+            )
+            return candidate
+    if "-" in channel_name:
+        prefix = lower_name.split("-", 1)[0]
+        if prefix:
+            logger.debug(
+                "Falling back to prefix-based modality '%s' for channel '%s'", prefix, channel_name
+            )
+            return prefix
+    logger.debug("No modality keyword found; defaulting to lowercase channel name '%s'", lower_name)
+    return lower_name
+
+
+__all__ = ["infer_modality"]

--- a/test/utils/test_modality.py
+++ b/test/utils/test_modality.py
@@ -1,0 +1,26 @@
+"""Tests for the shared modality inference helper."""
+
+from __future__ import annotations
+
+import unittest
+
+from pyblinker.utils.modality import infer_modality
+
+
+class TestInferModality(unittest.TestCase):
+    """Validate modality detection from channel names."""
+
+    def test_keyword_detection(self) -> None:
+        """Channels containing modality keywords map accordingly."""
+        self.assertEqual(infer_modality("EEG-E8"), "eeg")
+        self.assertEqual(infer_modality("EOG-EEG-eog_vert_left"), "eog")
+        self.assertEqual(infer_modality("EAR-avg_ear"), "ear")
+
+    def test_prefix_fallback(self) -> None:
+        """The channel prefix is used when no keyword is present."""
+        self.assertEqual(infer_modality("ECG-Lead1"), "ecg")
+        self.assertEqual(infer_modality("Fp1"), "fp1")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a shared `infer_modality` helper under `pyblinker.utils`
- update blink count, inter-blink interval, and segment blink property code to use the shared helper
- expose the helper via the utils package and add targeted unit coverage

## Testing
- `python -m pytest test/utils/test_modality.py`
- `python -m pytest test/blink_features/blink_events/test_blink_count.py -k multi_pick_modality_lookup`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68c947ab4cdc83258f53c28cf61c17db