### PR TITLE
Refactor blink feature computation into shared core

### DIFF
--- a/pyblinker/blink_features/_core_blink.py
+++ b/pyblinker/blink_features/_core_blink.py
@@ -1,0 +1,273 @@
+"""Shared blink waveform analytics used by per-blink feature functions."""
+
+from __future__ import annotations
+
+from typing import Dict, Iterable, Sequence
+
+import numpy as np
+
+from pyblinker.logging import get_logger
+
+logger = get_logger(__name__)
+
+#: Supported segmentation methods per modality. The EEG/EOG modality exposes
+#: all historical landmark strategies, while EAR (Eye Aspect Ratio) blinks do
+#: not have zero-crossings and therefore omit the ``zero`` variants.
+METHODS_BY_MODALITY: Dict[str, Sequence[str]] = {
+    "eeg": ("base", "zero", "tent", "half_base", "half_zero"),
+    "ear": ("base", "tent", "half_base"),
+}
+
+#: Ordered metric stems produced by :func:`compute_blink_core`.  The concrete
+#: keys are created by appending ``_{method}`` where ``method`` is one of the
+#: segmentation strategies above.
+CANONICAL_METRIC_STEMS: Sequence[str] = (
+    "area_abs_total_trapz",
+    "area_abs_total_rect",
+    "symmetry_trapz",
+    "symmetry_rect",
+    "rise_time_peak",
+    "fall_time_peak",
+    "rise_time_10_90",
+    "fall_time_10_90",
+    "half_width",
+    "vel_peak_abs",
+    "vel_mean_abs",
+    "slope_rise_pos",
+    "slope_fall_neg",
+    "acc_peak_abs",
+    "acc_mean_abs",
+    "amp_peak_signed",
+    "amp_trough_signed",
+    "amp_peak_to_trough",
+    "amp_peak_abs",
+)
+
+_ALL_METHODS = tuple(
+    sorted({method for methods in METHODS_BY_MODALITY.values() for method in methods})
+)
+_EPS = 1e-12
+
+
+def _method_keys(method: str) -> Sequence[str]:
+    return tuple(f"{stem}_{method}" for stem in CANONICAL_METRIC_STEMS)
+
+
+def core_nan_dict(keys: Iterable[str]) -> Dict[str, float]:
+    """Return a dictionary that maps ``keys`` to ``NaN`` values."""
+
+    return {key: float("nan") for key in keys}
+
+
+def _symmetry(left: float, right: float) -> float:
+    denom = left + right
+    if np.isnan(left) or np.isnan(right) or abs(denom) <= _EPS:
+        return float("nan")
+    return (left - right) / denom
+
+
+def _first_index_ge(values: np.ndarray, threshold: float) -> int | None:
+    matches = np.flatnonzero(values >= threshold)
+    return int(matches[0]) if matches.size else None
+
+
+def _first_index_le(values: np.ndarray, threshold: float) -> int | None:
+    matches = np.flatnonzero(values <= threshold)
+    return int(matches[0]) if matches.size else None
+
+
+def compute_blink_core(
+    segment: np.ndarray,
+    sfreq: float,
+    *,
+    start_end_method: str,
+    modality: str,
+    include_second_derivative: bool = True,
+    use_abs_for_thresholds_and_areas: bool = True,
+) -> Dict[str, float]:
+    """Compute canonical per-blink metrics for a segmented waveform.
+
+    Parameters
+    ----------
+    segment
+        One-dimensional signal segment spanning a single blink according to the
+        requested ``start_end_method``. The array is converted to ``float`` and
+        flattened internally.
+    sfreq
+        Sampling frequency in Hertz.
+    start_end_method
+        Segmentation strategy name (``"base"``, ``"zero"``, ``"tent"``,
+        ``"half_base"``, or ``"half_zero"``).
+    modality
+        Recording modality. ``"eeg"``/``"eog"`` retain zero-crossing metrics
+        whereas ``"ear"`` (Eye Aspect Ratio) omits them and returns ``NaN``.
+    include_second_derivative
+        If ``True`` (default) velocity and acceleration statistics are
+        reported. When ``False`` the acceleration metrics are set to ``NaN``.
+    use_abs_for_thresholds_and_areas
+        When ``True`` the magnitude used for rise/fall thresholds and area
+        calculations is based on ``abs(segment)`` for EEG/EOG data. EAR blinks
+        always rely on the dip magnitude relative to their local baseline and
+        ignore this flag.
+
+    Returns
+    -------
+    dict
+        Mapping of metric names (with method suffix) to numeric values. If the
+        segmentation method is not supported for the modality or the segment is
+        invalid, the returned values are ``NaN``.
+    """
+
+    method = start_end_method
+    if method not in _ALL_METHODS:
+        raise ValueError(f"Unknown start/end method: {method}")
+
+    modality_key = modality.lower()
+    if modality_key not in METHODS_BY_MODALITY:
+        raise ValueError(f"Unsupported modality '{modality}'")
+
+    keys = _method_keys(method)
+    if method not in METHODS_BY_MODALITY[modality_key]:
+        return core_nan_dict(keys)
+
+    if sfreq <= 0:
+        logger.warning("Non-positive sampling frequency %s; returning NaNs", sfreq)
+        return core_nan_dict(keys)
+
+    seg = np.asarray(segment, dtype=float).reshape(-1)
+    if seg.size == 0:
+        logger.debug("Empty blink segment provided for method '%s'", method)
+        return core_nan_dict(keys)
+
+    dt = 1.0 / float(sfreq)
+
+    peak_idx = int(np.argmax(seg))
+    trough_idx = int(np.argmin(seg))
+    amp_peak_signed = float(seg[peak_idx])
+    amp_trough_signed = float(seg[trough_idx])
+    amp_peak_to_trough = float(amp_peak_signed - amp_trough_signed)
+    amp_peak_abs = float(abs(amp_peak_signed))
+
+    if modality_key == "ear":
+        # EAR blink segments are dips relative to the open-eye baseline.  The
+        # magnitude used for thresholding and area computations therefore
+        # reflects the depth of the dip instead of absolute amplitude.
+        baseline_level = float(np.max(seg))
+        magnitude = np.clip(baseline_level - seg, a_min=0.0, a_max=None)
+    else:
+        baseline_level = 0.0
+        magnitude = (
+            np.abs(seg) if use_abs_for_thresholds_and_areas else np.asarray(seg)
+        )
+
+    mag_peak_idx = int(np.argmax(magnitude))
+    mag_peak_value = float(magnitude[mag_peak_idx])
+
+    area_total_trapz = float(np.trapezoid(magnitude, dx=dt))
+    area_left_trapz = float(np.trapezoid(magnitude[: mag_peak_idx + 1], dx=dt))
+    area_right_trapz = float(np.trapezoid(magnitude[mag_peak_idx:], dx=dt))
+
+    area_left_rect = float(np.sum(magnitude[:mag_peak_idx]) * dt)
+    area_right_rect = float(np.sum(magnitude[mag_peak_idx:]) * dt)
+    area_total_rect = float(np.sum(magnitude) * dt)
+
+    symmetry_trapz = _symmetry(area_left_trapz, area_right_trapz)
+    symmetry_rect = _symmetry(area_left_rect, area_right_rect)
+
+    rise_time_peak = mag_peak_idx / sfreq
+    fall_time_peak = (seg.size - 1 - mag_peak_idx) / sfreq
+
+    ten_level = 0.1 * mag_peak_value
+    ninety_level = 0.9 * mag_peak_value
+
+    rise_idx_10 = _first_index_ge(magnitude[: mag_peak_idx + 1], ten_level)
+    rise_idx_90 = _first_index_ge(magnitude[: mag_peak_idx + 1], ninety_level)
+    if rise_idx_10 is None or rise_idx_90 is None or rise_idx_90 <= rise_idx_10:
+        rise_time_10_90 = float("nan")
+    else:
+        rise_time_10_90 = (rise_idx_90 - rise_idx_10) / sfreq
+
+    fall_idx_90_rel = _first_index_le(magnitude[mag_peak_idx:], ninety_level)
+    if fall_idx_90_rel is None:
+        fall_time_10_90 = float("nan")
+    else:
+        fall_idx_90 = mag_peak_idx + fall_idx_90_rel
+        fall_idx_10_rel = _first_index_le(magnitude[fall_idx_90:], ten_level)
+        if fall_idx_10_rel is None:
+            fall_time_10_90 = float("nan")
+        else:
+            fall_idx_10 = fall_idx_90 + fall_idx_10_rel
+            if fall_idx_10 <= fall_idx_90:
+                fall_time_10_90 = float("nan")
+            else:
+                fall_time_10_90 = (fall_idx_10 - fall_idx_90) / sfreq
+
+    half_level = 0.5 * mag_peak_value
+    left_half_idx = _first_index_ge(magnitude[: mag_peak_idx + 1], half_level)
+    right_half_candidates = np.flatnonzero(
+        magnitude[mag_peak_idx + 1 :] <= half_level
+    )
+    if left_half_idx is None or right_half_candidates.size == 0:
+        half_width = float("nan")
+    else:
+        right_half_idx = mag_peak_idx + 1 + int(right_half_candidates[0])
+        half_width = (right_half_idx - left_half_idx) / sfreq
+
+    velocity = np.diff(seg) * sfreq
+    if velocity.size == 0:
+        vel_peak_abs = float("nan")
+        vel_mean_abs = float("nan")
+        slope_rise_pos = float("nan")
+        slope_fall_neg = float("nan")
+    else:
+        abs_vel = np.abs(velocity)
+        vel_peak_abs = float(np.max(abs_vel))
+        vel_mean_abs = float(np.mean(abs_vel))
+        slope_rise_pos = float(np.max(velocity))
+        slope_fall_neg = float(np.min(velocity))
+
+    if include_second_derivative and velocity.size > 1:
+        acceleration = np.diff(velocity) * sfreq
+        abs_acc = np.abs(acceleration)
+        acc_peak_abs = float(np.max(abs_acc))
+        acc_mean_abs = float(np.mean(abs_acc))
+    else:
+        acc_peak_abs = float("nan")
+        acc_mean_abs = float("nan")
+
+    metrics = {
+        f"area_abs_total_trapz_{method}": area_total_trapz,
+        f"area_abs_total_rect_{method}": area_total_rect,
+        f"symmetry_trapz_{method}": symmetry_trapz,
+        f"symmetry_rect_{method}": symmetry_rect,
+        f"rise_time_peak_{method}": rise_time_peak,
+        f"fall_time_peak_{method}": fall_time_peak,
+        f"rise_time_10_90_{method}": rise_time_10_90,
+        f"fall_time_10_90_{method}": fall_time_10_90,
+        f"half_width_{method}": half_width,
+        f"vel_peak_abs_{method}": vel_peak_abs,
+        f"vel_mean_abs_{method}": vel_mean_abs,
+        f"slope_rise_pos_{method}": slope_rise_pos,
+        f"slope_fall_neg_{method}": slope_fall_neg,
+        f"acc_peak_abs_{method}": acc_peak_abs,
+        f"acc_mean_abs_{method}": acc_mean_abs,
+        f"amp_peak_signed_{method}": amp_peak_signed,
+        f"amp_trough_signed_{method}": amp_trough_signed,
+        f"amp_peak_to_trough_{method}": amp_peak_to_trough,
+        f"amp_peak_abs_{method}": amp_peak_abs,
+    }
+
+    return metrics
+
+
+ALL_METHODS = _ALL_METHODS
+
+
+__all__ = [
+    "CANONICAL_METRIC_STEMS",
+    "METHODS_BY_MODALITY",
+    "ALL_METHODS",
+    "compute_blink_core",
+    "core_nan_dict",
+]
+

--- a/pyblinker/blink_features/kinematics/per_blink.py
+++ b/pyblinker/blink_features/kinematics/per_blink.py
@@ -1,126 +1,95 @@
-"""Per-blink kinematic metrics based on metadata windows."""
+"""Per-blink kinematic metrics delegated to the shared blink core."""
 
 from __future__ import annotations
-from pyblinker.logging import get_logger
 
-from typing import Dict
+from typing import Dict, Iterable, Mapping
 
 import numpy as np
 
-logger = get_logger(__name__)
+from .._core_blink import METHODS_BY_MODALITY, compute_blink_core
 
 
-def compute_segment_kinematics(segment: np.ndarray, sfreq: float) -> Dict[str, float]:
-    """Compute kinematic quantities for a single blink segment.
+def _normalize_methods(modality: str, methods: Iterable[str] | None) -> tuple[str, ...]:
+    modality_key = modality.lower()
+    allowed = METHODS_BY_MODALITY.get(modality_key, ("base",))
+    if methods is None:
+        return (allowed[0],)
+    ordered = []
+    for method in methods:
+        if method not in ordered:
+            ordered.append(method)
+    return tuple(ordered) if ordered else (allowed[0],)
+
+
+def compute_segment_kinematics(
+    segment: np.ndarray | Mapping[str, np.ndarray],
+    sfreq: float,
+    *,
+    methods: Iterable[str] | None = None,
+    modality: str = "eeg",
+    include_second_derivative: bool = True,
+    use_abs_for_thresholds_and_areas: bool = True,
+) -> Dict[str, float]:
+    """Compute blink kinematic metrics for one or more segmentation methods.
 
     Parameters
     ----------
-    segment : numpy.ndarray
-        1-D array containing the signal samples for the blink.
-    sfreq : float
-        Sampling frequency of ``segment`` in Hertz.
+    segment
+        Either a one-dimensional array representing the blink waveform or a
+        mapping of ``{method: segment}``. When a single array is provided the
+        function defaults to the first supported method for the modality (base
+        for EEG/EOG, base for EAR). Passing a mapping allows callers to provide
+        distinct start/end windows for multiple methods in a single call.
+    sfreq
+        Sampling frequency of the provided segments.
+    methods
+        Optional iterable of method names to evaluate when ``segment`` is an
+        array. Ignored when ``segment`` is a mapping.
+    modality
+        Recording modality. ``"eeg"`` (default) enables zero-based metrics
+        whereas ``"ear"`` (Eye Aspect Ratio) suppresses them.
+    include_second_derivative
+        Forwarded to :func:`pyblinker.blink_features._core_blink.compute_blink_core`.
+    use_abs_for_thresholds_and_areas
+        Forwarded to the shared core. Ignored for EAR data where dip magnitude
+        is computed relative to the local baseline.
 
     Returns
     -------
     dict
-        Mapping of metric name to value. ``NaN`` is returned for metrics that
-        cannot be computed due to short segments or non-monotonicity.
+        Mapping of metric names with method suffixes to floating point values.
     """
 
-    seg = np.asarray(segment, dtype=float)
-    if seg.size == 0:
-        logger.warning("Empty blink segment provided. Returning NaNs.")
-        return {metric: float("nan") for metric in (
-            "peak_amp",
-            "t2p",
-            "vel_mean",
-            "vel_peak",
-            "acc_mean",
-            "acc_peak",
-            "rise_time",
-            "fall_time",
-            "auc",
-            "symmetry",
-        )}
-
-    abs_seg = np.abs(seg)
-    peak_amp = float(np.max(abs_seg))
-    peak_idx = int(np.argmax(abs_seg))
-    t2p = peak_idx / sfreq
-
-    if seg.size >= 2:
-        velocity = np.diff(seg) * sfreq
-        abs_vel = np.abs(velocity)
-        vel_mean = float(np.mean(abs_vel))
-        vel_peak = float(np.max(abs_vel))
+    if isinstance(segment, Mapping):
+        segments_by_method = {
+            method: np.asarray(data, dtype=float).reshape(-1)
+            for method, data in segment.items()
+        }
+        method_order = tuple(segments_by_method.keys())
     else:
-        vel_mean = float("nan")
-        vel_peak = float("nan")
+        seg_array = np.asarray(segment, dtype=float).reshape(-1)
+        method_order = _normalize_methods(modality, methods)
+        segments_by_method = {method: seg_array for method in method_order}
 
-    if seg.size >= 3:
-        acceleration = np.diff(np.diff(seg)) * (sfreq ** 2)
-        abs_acc = np.abs(acceleration)
-        acc_mean = float(np.mean(abs_acc))
-        acc_peak = float(np.max(abs_acc))
-    else:
-        acc_mean = float("nan")
-        acc_peak = float("nan")
+    if not segments_by_method:
+        method_order = _normalize_methods(modality, None)
+        if isinstance(segment, Mapping):
+            seg_array = np.asarray([], dtype=float)
+        else:
+            seg_array = np.asarray(segment, dtype=float).reshape(-1)
+        segments_by_method = {method_order[0]: seg_array}
 
-    ten = 0.1 * peak_amp
-    ninety = 0.9 * peak_amp
-
-    # Rise time
-    idx_10 = next((i for i in range(peak_idx + 1) if abs_seg[i] >= ten), None)
-    idx_90 = next((i for i in range(peak_idx + 1) if abs_seg[i] >= ninety), None)
-    if (
-        idx_10 is not None
-        and idx_90 is not None
-        and idx_90 > idx_10
-        and np.all(np.diff(abs_seg[idx_10 : idx_90 + 1]) >= 0)
-    ):
-        rise_time = (idx_90 - idx_10) / sfreq
-    else:
-        rise_time = float("nan")
-
-    # Fall time
-    idx_90_fall = None
-    for i in range(peak_idx, abs_seg.size):
-        if abs_seg[i] <= ninety:
-            idx_90_fall = i
-            break
-    idx_10_fall = None
-    if idx_90_fall is not None:
-        for i in range(idx_90_fall, abs_seg.size):
-            if abs_seg[i] <= ten:
-                idx_10_fall = i
-                break
-    if (
-        idx_90_fall is not None
-        and idx_10_fall is not None
-        and idx_10_fall > idx_90_fall
-        and np.all(np.diff(abs_seg[idx_90_fall : idx_10_fall + 1]) <= 0)
-    ):
-        fall_time = (idx_10_fall - idx_90_fall) / sfreq
-    else:
-        fall_time = float("nan")
-
-    auc = float(np.sum(abs_seg) / sfreq)
-    area_left = float(np.sum(abs_seg[:peak_idx]) / sfreq)
-    area_right = float(np.sum(abs_seg[peak_idx:]) / sfreq)
-    symmetry = (area_left - area_right) / (area_left + area_right + 1e-8)
-
-    metrics = {
-        "peak_amp": peak_amp,
-        "t2p": t2p,
-        "vel_mean": vel_mean,
-        "vel_peak": vel_peak,
-        "acc_mean": acc_mean,
-        "acc_peak": acc_peak,
-        "rise_time": rise_time,
-        "fall_time": fall_time,
-        "auc": auc,
-        "symmetry": symmetry,
-    }
-
-    logger.debug("Per-blink kinematics: %s", metrics)
+    metrics: Dict[str, float] = {}
+    modality_key = modality.lower()
+    for method in method_order:
+        metrics.update(
+            compute_blink_core(
+                segments_by_method[method],
+                sfreq,
+                start_end_method=method,
+                modality=modality_key,
+                include_second_derivative=include_second_derivative,
+                use_abs_for_thresholds_and_areas=use_abs_for_thresholds_and_areas,
+            )
+        )
     return metrics

--- a/pyblinker/blink_features/morphology/epoch_features.py
+++ b/pyblinker/blink_features/morphology/epoch_features.py
@@ -5,29 +5,19 @@ from pyblinker.logging import get_logger
 from typing import Dict, List, Sequence
 
 import mne
+import numpy as np
 import pandas as pd
 
 from .per_blink import compute_blink_waveform_metrics
 from ..energy.helpers import extract_blink_windows, segment_to_samples, _safe_stats
+from ...utils.modality import infer_modality
 
 logger = get_logger(__name__)
 
-# Ordered names of per-blink morphology metrics. Enumerated explicitly to
-# avoid calling ``compute_blink_waveform_metrics`` during import.
-WAVEFORM_METRICS: tuple[str, ...] = (
-    "peak_amplitude",
-    "trough_amplitude",
-    "peak_to_peak",
-    "area_abs",
-    "rise_time",
-    "fall_time",
-    "half_width",
-    "slope_rise",
-    "slope_fall",
-)
+_BASE_METRICS = tuple(compute_blink_waveform_metrics(np.zeros(3), 1.0).keys())
 
 # Derive metric and statistic names instead of hardcoding
-_METRICS = WAVEFORM_METRICS + ("duration",)
+_METRICS = _BASE_METRICS + ("duration",)
 _STATS = tuple(_safe_stats([]).keys())
 
 
@@ -106,14 +96,19 @@ def compute_epoch_morphology_features(
         for ch_idx, ch_name in enumerate(ch_names):
             windows = extract_blink_windows(meta_row, ch_name, ei)
             per_metric: Dict[str, List[float]] = {m: [] for m in _METRICS}
+            channel_modality = infer_modality(ch_name)
+            modality_key = "eeg" if channel_modality == "eog" else channel_modality
             for onset_s, duration_s in windows:
                 sl = segment_to_samples(onset_s, duration_s, sfreq, n_times)
                 segment = data[ei, ch_idx, sl]
-                metrics = compute_blink_waveform_metrics(segment, sfreq)
-                if metrics is None:
-                    continue
-                for m, val in metrics.items():
-                    per_metric[m].append(val)
+                metrics = compute_blink_waveform_metrics(
+                    segment,
+                    sfreq,
+                    methods=("base",),
+                    modality=modality_key,
+                )
+                for metric_name in _BASE_METRICS:
+                    per_metric[metric_name].append(metrics.get(metric_name, float("nan")))
                 per_metric["duration"].append(duration_s)
             for metric in _METRICS:
                 stats = _safe_stats(per_metric[metric])

--- a/pyblinker/blink_features/morphology/per_blink.py
+++ b/pyblinker/blink_features/morphology/per_blink.py
@@ -1,82 +1,74 @@
-"""Per-blink morphology feature calculations."""
-from __future__ import annotations
-from pyblinker.logging import get_logger
+"""Per-blink morphology metrics delegated to the shared blink core."""
 
-from typing import Dict, Optional
+from __future__ import annotations
+
+from typing import Dict, Iterable, Mapping
 
 import numpy as np
 
-logger = get_logger(__name__)
+from .._core_blink import METHODS_BY_MODALITY, compute_blink_core
 
 
-def compute_blink_waveform_metrics(segment: np.ndarray, sfreq: float) -> Optional[Dict[str, float]]:
-    """Compute morphology metrics for a single blink waveform.
+def _normalize_methods(modality: str, methods: Iterable[str] | None) -> tuple[str, ...]:
+    modality_key = modality.lower()
+    allowed = METHODS_BY_MODALITY.get(modality_key, ("base",))
+    if methods is None:
+        return (allowed[0],)
+    ordered: list[str] = []
+    for method in methods:
+        if method not in ordered:
+            ordered.append(method)
+    return tuple(ordered) if ordered else (allowed[0],)
 
-    Parameters
-    ----------
-    segment : numpy.ndarray
-        One-dimensional blink waveform. The segment is expected to start and end
-        at the eyelid baseline.
-    sfreq : float
-        Sampling frequency in Hertz.
 
-    Returns
-    -------
-    dict or None
-        Dictionary with morphology metrics or ``None`` if the segment is too
-        short to evaluate.
+def compute_blink_waveform_metrics(
+    segment: np.ndarray | Mapping[str, np.ndarray],
+    sfreq: float,
+    *,
+    methods: Iterable[str] | None = None,
+    modality: str = "eeg",
+    include_second_derivative: bool = True,
+    use_abs_for_thresholds_and_areas: bool = True,
+) -> Dict[str, float]:
+    """Compute morphology-oriented blink metrics for selected methods.
 
-    Notes
-    -----
-    ``rise_time`` measures the latency from segment start to peak amplitude,
-    while ``fall_time`` spans from the peak back to the segment end. The
-    ``half_width`` corresponds to the full width at half of the peak-to-peak
-    amplitude. ``slope_rise`` and ``slope_fall`` capture the extreme positive
-    and negative derivatives of the waveform.
+    The signature mirrors :func:`pyblinker.blink_features.kinematics.per_blink.
+    compute_segment_kinematics` so callers can interchange the two depending on
+    their feature subset needs. The returned key space is identical to the
+    kinematic helper and all signal analytics are delegated to
+    :func:`pyblinker.blink_features._core_blink.compute_blink_core`.
     """
-    segment = np.asarray(segment, dtype=float)
-    if segment.size < 3:
-        logger.debug("Segment too short for morphology metrics: len=%d", segment.size)
-        return None
 
-    peak_idx = int(np.argmax(segment))
-    trough_idx = int(np.argmin(segment))
-    peak = float(segment[peak_idx])
-    trough = float(segment[trough_idx])
-    peak_to_peak = float(peak - trough)
-    area_abs = float(np.trapezoid(np.abs(segment), dx=1.0 / sfreq))
-
-    rise_time = peak_idx / sfreq
-    fall_time = (segment.size - 1 - peak_idx) / sfreq
-
-    half_level = trough + 0.5 * peak_to_peak
-    left = next((i for i in range(peak_idx, -1, -1) if segment[i] <= half_level), None)
-    right = next((i for i in range(peak_idx, segment.size) if segment[i] <= half_level), None)
-    if left is None or right is None or right <= left:
-        half_width = float("nan")
+    if isinstance(segment, Mapping):
+        segments_by_method = {
+            method: np.asarray(data, dtype=float).reshape(-1)
+            for method, data in segment.items()
+        }
+        method_order = tuple(segments_by_method.keys())
     else:
-        half_width = (right - left) / sfreq
+        seg_array = np.asarray(segment, dtype=float).reshape(-1)
+        method_order = _normalize_methods(modality, methods)
+        segments_by_method = {method: seg_array for method in method_order}
 
-    deriv = np.diff(segment) * sfreq
-    if deriv.size == 0:
-        slope_rise = float("nan")
-        slope_fall = float("nan")
-    else:
-        slope_rise = float(np.max(deriv))
-        slope_fall = float(np.min(deriv))
+    if not segments_by_method:
+        method_order = _normalize_methods(modality, None)
+        if isinstance(segment, Mapping):
+            seg_array = np.asarray([], dtype=float)
+        else:
+            seg_array = np.asarray(segment, dtype=float).reshape(-1)
+        segments_by_method = {method_order[0]: seg_array}
 
-    logger.debug(
-        "Blink metrics: peak=%s trough=%s peak_to_peak=%s", peak, trough, peak_to_peak
-    )
-
-    return {
-        "peak_amplitude": peak,
-        "trough_amplitude": trough,
-        "peak_to_peak": peak_to_peak,
-        "area_abs": area_abs,
-        "rise_time": rise_time,
-        "fall_time": fall_time,
-        "half_width": half_width,
-        "slope_rise": slope_rise,
-        "slope_fall": slope_fall,
-    }
+    metrics: Dict[str, float] = {}
+    modality_key = modality.lower()
+    for method in method_order:
+        metrics.update(
+            compute_blink_core(
+                segments_by_method[method],
+                sfreq,
+                start_end_method=method,
+                modality=modality_key,
+                include_second_derivative=include_second_derivative,
+                use_abs_for_thresholds_and_areas=use_abs_for_thresholds_and_areas,
+            )
+        )
+    return metrics

--- a/pyblinker/blink_features/waveform_features/extract_blink_properties.py
+++ b/pyblinker/blink_features/waveform_features/extract_blink_properties.py
@@ -1,3 +1,5 @@
+from typing import Literal, Tuple
+
 import numpy as np
 import pandas as pd
 
@@ -21,6 +23,11 @@ class BlinkProperties:
         the input candidate_signal, DataFrame of blink fits, sampling rate, and parameters.
         It initializes blink velocity, durations, amplitude-velocity ratios,
         and time-related features.
+
+        The optional ``params['modality']`` flag controls whether zero-based
+        landmarks are considered. ``"ear"`` modality retains the schema but
+        fills all ``*_zero`` columns with ``NaN`` because Eye Aspect Ratio
+        blinks lack zero crossings.
 
         Parameters
         ----------
@@ -50,6 +57,12 @@ class BlinkProperties:
         self.shut_amp_fraction = params["shut_amp_fraction"]
         self.p_avr_threshold = params["p_avr_threshold"]
         self.z_thresholds = params["z_thresholds"]
+
+        modality_param = params.get("modality", "eeg")
+        modality_norm = str(modality_param).lower()
+        if modality_norm == "eog":
+            modality_norm = "eeg"
+        self.modality: Literal["eeg", "ear"] = "ear" if modality_norm == "ear" else "eeg"
 
         self.fitted = fitted
 
@@ -81,9 +94,12 @@ class BlinkProperties:
         self.df["duration_base"] = (
             self.df["right_base"] - self.df["left_base"]
         ) / self.srate
-        self.df["duration_zero"] = (
-            self.df["right_zero"] - self.df["left_zero"]
-        ) / self.srate
+        if {"right_zero", "left_zero"}.issubset(self.df.columns) and self.modality != "ear":
+            self.df["duration_zero"] = (
+                self.df["right_zero"] - self.df["left_zero"]
+            ) / self.srate
+        else:
+            self.df["duration_zero"] = np.nan
 
         if self.fitted:
             self.df["duration_tent"] = (
@@ -92,9 +108,15 @@ class BlinkProperties:
             self.df["duration_half_base"] = (
                 (self.df["right_base_half_height"] - self.df["left_base_half_height"]) + constant
             ) / self.srate
-            self.df["duration_half_zero"] = (
-                (self.df["right_zero_half_height"] - self.df["left_zero_half_height"]) + constant
-            ) / self.srate
+            if (
+                {"right_zero_half_height", "left_zero_half_height"}.issubset(self.df.columns)
+                and self.modality != "ear"
+            ):
+                self.df["duration_half_zero"] = (
+                    (self.df["right_zero_half_height"] - self.df["left_zero_half_height"]) + constant
+                ) / self.srate
+            else:
+                self.df["duration_half_zero"] = np.nan
 
     def compute_amplitude_velocity_ratio(
         self, start_key, end_key, ratio_key, aggregator="max", idx_col=None
@@ -172,6 +194,12 @@ class BlinkProperties:
 
     def set_blink_amp_velocity_ratio_zero_to_max(self):
         """ "Computes and sets both positive and negative amplitude-velocity ratios (zero-to-max)."""
+        if self.modality == "ear":
+            self.df["pos_amp_vel_ratio_zero"] = np.nan
+            self.df["neg_amp_vel_ratio_zero"] = np.nan
+            self.df["peaks_pos_vel_zero"] = np.nan
+            return
+
         self.compute_pos_amp_vel_ratio_zero()
         self.compute_neg_amp_vel_ratio_zero()
 
@@ -278,6 +306,12 @@ class BlinkProperties:
         Time zero shut
         :return:
         """
+        if "left_zero" not in self.df.columns or self.modality == "ear":
+            self.df["closing_time_zero"] = np.nan
+            self.df["reopening_time_zero"] = np.nan
+            self.df["time_shut_zero"] = np.nan
+            return
+
         self.df["closing_time_zero"] = (
             self.df["max_blink"] - self.df["left_zero"]
         ) / self.srate
@@ -285,14 +319,14 @@ class BlinkProperties:
             self.df["right_zero"] - self.df["max_blink"]
         ) / self.srate
 
-        self.df["time_shut_base"] = self.df.apply(
+        self.df["time_shut_zero"] = self.df.apply(
             lambda row: self.compute_time_shut(
                 row,
                 self.candidate_signal,
                 self.srate,
                 self.shut_amp_fraction,
-                key_prefix="Base",
-                default_no_thresh=0,
+                key_prefix="Zero",
+                default_no_thresh=np.nan,
             ),
             axis=1,
         )
@@ -379,6 +413,44 @@ class BlinkProperties:
         self.df["inter_blink_max_vel_base"] = (
             self.df["peaks_pos_vel_base"] * -1
         ) / self.srate
-        self.df["inter_blink_max_vel_zero"] = (
-            self.df["peaks_pos_vel_zero"] * -1
-        ) / self.srate
+        if self.modality == "ear":
+            self.df["inter_blink_max_vel_zero"] = np.nan
+        else:
+            self.df["inter_blink_max_vel_zero"] = (
+                self.df["peaks_pos_vel_zero"] * -1
+            ) / self.srate
+
+    def blink_bounds(self, row: pd.Series, method: str) -> Tuple[int, int] | None:
+        """Return inclusive (left, right) indices for the requested method."""
+
+        method_key = method.lower()
+        mapping = {
+            "base": ("left_base", "right_base"),
+            "zero": ("left_zero", "right_zero"),
+            "tent": ("left_x_intercept", "right_x_intercept"),
+            "half_base": ("left_base_half_height", "right_base_half_height"),
+            "half_zero": ("left_zero_half_height", "right_zero_half_height"),
+        }
+        if method_key not in mapping:
+            raise ValueError(f"Unknown blink boundary method: {method}")
+        if self.modality == "ear" and "zero" in method_key:
+            return None
+
+        left_col, right_col = mapping[method_key]
+        if left_col not in row or right_col not in row:
+            return None
+
+        left_val = row[left_col]
+        right_val = row[right_col]
+        if pd.isna(left_val) or pd.isna(right_val):
+            return None
+
+        try:
+            left_idx = int(round(float(left_val)))
+            right_idx = int(round(float(right_val)))
+        except (TypeError, ValueError):
+            return None
+
+        if right_idx < left_idx:
+            return None
+        return left_idx, right_idx

--- a/pyblinker/segment_blink_properties.py
+++ b/pyblinker/segment_blink_properties.py
@@ -29,10 +29,23 @@ from .utils.metadata_utils import (
 )
 
 from .blinker.fit_blink import FitBlinks
+from .blink_features._core_blink import (
+    ALL_METHODS,
+    CANONICAL_METRIC_STEMS,
+    METHODS_BY_MODALITY,
+    core_nan_dict,
+)
+from .blink_features.kinematics.per_blink import compute_segment_kinematics
+from .blink_features.morphology.per_blink import compute_blink_waveform_metrics
 from .blink_features.waveform_features.extract_blink_properties import BlinkProperties
 from .utils import normalize_picks, require_channels
 from .utils.modality import infer_modality
 from .blinker.zero_crossing import left_right_zero_crossing
+
+_METHOD_METRIC_KEYS = {
+    method: [f"{stem}_{method}" for stem in CANONICAL_METRIC_STEMS]
+    for method in ALL_METHODS
+}
 
 logger = get_logger(__name__)
 
@@ -394,7 +407,14 @@ def fit_and_extract_properties(
     run_fit: bool,
 ) -> pd.DataFrame | None:
     """Run :class:`FitBlinks` and :class:`BlinkProperties` to obtain metrics."""
-    fitter = FitBlinks(candidate_signal=signal, df=rows.copy(), params=params)
+    modality_override = None
+    if "modality" in rows.columns and not rows.empty:
+        modality_override = rows.iloc[0]["modality"]
+    params_local = dict(params)
+    if modality_override is not None:
+        params_local["modality"] = modality_override
+
+    fitter = FitBlinks(candidate_signal=signal, df=rows.copy(), params=params_local)
     try:
         fitter.dprocess_segment_raw(run_fit=run_fit)
     except Exception:
@@ -404,5 +424,56 @@ def fit_and_extract_properties(
     if frame_blinks is None or frame_blinks.empty:
         return None
 
-    return BlinkProperties(signal, frame_blinks, sfreq, params, fitted=run_fit).df
+    blink_properties = BlinkProperties(
+        signal, frame_blinks, sfreq, params_local, fitted=run_fit
+    )
+    props_df = blink_properties.df
+    if props_df.empty:
+        return props_df
+
+    modality = blink_properties.modality
+    allowed_methods = METHODS_BY_MODALITY.get(modality, ())
+
+    metric_records: List[Dict[str, float]] = []
+    n_samples = signal.shape[0]
+    for _, row in props_df.iterrows():
+        row_metrics: Dict[str, float] = {}
+        for method in ALL_METHODS:
+            method_keys = _METHOD_METRIC_KEYS[method]
+            if method not in allowed_methods:
+                row_metrics.update(core_nan_dict(method_keys))
+                continue
+
+            bounds = blink_properties.blink_bounds(row, method)
+            if bounds is None:
+                row_metrics.update(core_nan_dict(method_keys))
+                continue
+
+            start_idx, end_idx = bounds
+            start_idx = max(0, min(n_samples - 1, int(start_idx)))
+            end_idx = max(0, min(n_samples - 1, int(end_idx)))
+            if end_idx < start_idx:
+                row_metrics.update(core_nan_dict(method_keys))
+                continue
+
+            segment = signal[start_idx : end_idx + 1]
+            metrics = compute_segment_kinematics(
+                segment,
+                sfreq,
+                methods=(method,),
+                modality=modality,
+            )
+            waveform_metrics = compute_blink_waveform_metrics(
+                segment,
+                sfreq,
+                methods=(method,),
+                modality=modality,
+            )
+            metrics.update(waveform_metrics)
+            row_metrics.update(metrics)
+
+        metric_records.append(row_metrics)
+
+    metrics_df = pd.DataFrame(metric_records, index=props_df.index)
+    return pd.concat([props_df, metrics_df], axis=1)
 

--- a/test/blink_features/kinematics/test_kinematic_feature_aggregation.py
+++ b/test/blink_features/kinematics/test_kinematic_feature_aggregation.py
@@ -6,9 +6,11 @@ import unittest
 from pathlib import Path
 
 import mne
+import numpy as np
 import pandas as pd
 
 from pyblinker.blink_features.kinematics import compute_kinematic_features
+from pyblinker.blink_features.kinematics.per_blink import compute_segment_kinematics
 from pyblinker.utils.refinement_utils import slice_raw_into_mne_epochs_refine_annot
 
 from ..utils.helpers import assert_df_has_columns, assert_numeric_or_nan
@@ -42,20 +44,11 @@ class TestKinematicFeatureAggregation(unittest.TestCase):
         blink_counts = pd.read_csv(blink_counts_path, index_col="epoch_id")
         df = df.join(blink_counts)
 
-        metrics = [
-            "peak_amp",
-            "t2p",
-            "vel_mean",
-            "vel_peak",
-            "acc_mean",
-            "acc_peak",
-            "rise_time",
-            "fall_time",
-            "auc",
-            "symmetry",
-        ]
+        metric_keys = tuple(
+            compute_segment_kinematics(np.zeros(3), 1.0, methods=("base",)).keys()
+        )
         expected_cols = [
-            f"{m}_{s}_{ch}" for m in metrics for s in ("mean", "std", "cv")
+            f"{m}_{s}_{ch}" for m in metric_keys for s in ("mean", "std", "cv")
         ]
         assert_df_has_columns(self, df, expected_cols + ["blink_count"])
         assert_numeric_or_nan(self, df.iloc[0])

--- a/test/blink_features/kinematics/test_kinematic_features.py
+++ b/test/blink_features/kinematics/test_kinematic_features.py
@@ -6,6 +6,7 @@ import unittest
 from pathlib import Path
 
 import mne
+import numpy as np
 
 from pyblinker.blink_features.kinematics import compute_kinematic_features
 from pyblinker.blink_features.kinematics.per_blink import compute_segment_kinematics
@@ -37,20 +38,11 @@ class TestKinematicFeatures(unittest.TestCase):
         ch = "EEG-E8"
         df = compute_kinematic_features(self.epochs, picks=ch)
 
-        metrics = [
-            "peak_amp",
-            "t2p",
-            "vel_mean",
-            "vel_peak",
-            "acc_mean",
-            "acc_peak",
-            "rise_time",
-            "fall_time",
-            "auc",
-            "symmetry",
-        ]
+        metric_keys = tuple(
+            compute_segment_kinematics(np.zeros(3), 1.0, methods=("base",)).keys()
+        )
         expected_cols = [
-            f"{m}_{s}_{ch}" for m in metrics for s in ("mean", "std", "cv")
+            f"{m}_{s}_{ch}" for m in metric_keys for s in ("mean", "std", "cv")
         ]
         assert_df_has_columns(self, df, expected_cols)
         assert_numeric_or_nan(self, df.iloc[0])
@@ -68,24 +60,16 @@ class TestKinematicFeatures(unittest.TestCase):
         data = self.epochs.get_data(picks=[ch])
         meta = self.epochs.metadata.iloc[0]
         windows = extract_blink_windows(meta, ch, 0)
-        per_metric = {m: [] for m in (
-            "peak_amp",
-            "t2p",
-            "vel_mean",
-            "vel_peak",
-            "acc_mean",
-            "acc_peak",
-            "rise_time",
-            "fall_time",
-            "auc",
-            "symmetry",
-        )}
+        metric_keys = tuple(
+            compute_segment_kinematics(np.zeros(3), 1.0, methods=("base",)).keys()
+        )
+        per_metric = {m: [] for m in metric_keys}
         n_times = data.shape[-1]
         for onset, dur in windows:
             sl = segment_to_samples(onset, dur, sfreq, n_times)
             seg = data[0, 0, sl]
-            metrics = compute_segment_kinematics(seg, sfreq)
-            for m in per_metric:
+            metrics = compute_segment_kinematics(seg, sfreq, methods=("base",))
+            for m in metric_keys:
                 per_metric[m].append(metrics[m])
 
         manual = {}
@@ -96,6 +80,28 @@ class TestKinematicFeatures(unittest.TestCase):
 
         for key, val in manual.items():
             self.assertAlmostEqual(df.iloc[0][key], val, places=7)
+
+    def test_method_suffix_and_modality_guard(self) -> None:
+        """Per-blink metrics include method suffixes and respect modality rules."""
+        segment = np.array([0.0, 1.0, 0.2, 0.0])
+        metrics = compute_segment_kinematics(
+            {"base": segment, "half_base": segment},
+            100.0,
+            modality="eeg",
+        )
+        self.assertIn("area_abs_total_trapz_base", metrics)
+        self.assertIn("area_abs_total_trapz_half_base", metrics)
+
+        ear_metrics = compute_segment_kinematics(
+            segment,
+            100.0,
+            methods=("zero",),
+            modality="ear",
+        )
+        self.assertTrue(
+            np.isnan(ear_metrics["area_abs_total_trapz_zero"]),
+            msg="EAR zero-crossing metrics should be NaN",
+        )
 
 
 if __name__ == "__main__":

--- a/test/blink_features/morphology/test_epoch_morphology_features.py
+++ b/test/blink_features/morphology/test_epoch_morphology_features.py
@@ -5,8 +5,10 @@ import unittest
 from pathlib import Path
 
 import mne
+import numpy as np
 
 from pyblinker.blink_features.morphology import compute_epoch_morphology_features
+from pyblinker.blink_features.morphology.per_blink import compute_blink_waveform_metrics
 from pyblinker.utils.refinement_utils import slice_raw_into_mne_epochs_refine_annot
 
 from ..utils.helpers import (
@@ -62,6 +64,23 @@ class TestEpochMorphologyFeatures(unittest.TestCase):
         df = compute_epoch_morphology_features(self.epochs[:0], picks=picks)
         assert_df_has_columns(self, df, morphology_column_names(picks))
         self.assertEqual(len(df), 0)
+
+    def test_waveform_metric_suffixes(self) -> None:
+        """Waveform metrics expose method suffixes and modality-specific NaNs."""
+        segment = np.array([0.0, 0.5, 0.1, 0.0])
+        metrics = compute_blink_waveform_metrics(
+            {"base": segment, "tent": segment}, 100.0, modality="eeg"
+        )
+        self.assertIn("area_abs_total_rect_base", metrics)
+        self.assertIn("area_abs_total_rect_tent", metrics)
+
+        ear_metrics = compute_blink_waveform_metrics(
+            segment, 100.0, methods=("zero",), modality="ear"
+        )
+        self.assertTrue(
+            np.isnan(ear_metrics["area_abs_total_rect_zero"]),
+            msg="EAR modality should yield NaN for zero-crossing metrics",
+        )
 
 
 if __name__ == "__main__":

--- a/test/blink_features/utils/helpers.py
+++ b/test/blink_features/utils/helpers.py
@@ -7,8 +7,8 @@ from contextlib import contextmanager
 import numpy as np
 import pandas as pd
 
+from pyblinker.blink_features._core_blink import CANONICAL_METRIC_STEMS
 from pyblinker.blink_features.energy.helpers import _safe_stats
-from pyblinker.blink_features.morphology.epoch_features import WAVEFORM_METRICS
 
 
 def assert_numeric_or_nan(testcase, values: Iterable[float]) -> None:
@@ -33,6 +33,6 @@ def assert_df_has_columns(testcase, df: pd.DataFrame, columns: Sequence[str]) ->
 
 def morphology_column_names(channels: Sequence[str]) -> List[str]:
     """Return expected morphology feature columns for given channels."""
-    metrics = WAVEFORM_METRICS + ("duration",)
+    metrics = tuple(f"{stem}_base" for stem in CANONICAL_METRIC_STEMS) + ("duration",)
     stats = tuple(_safe_stats([]).keys())
     return [f"{m}_{s}_{ch}" for ch in channels for m in metrics for s in stats]


### PR DESCRIPTION
## Summary
- add a shared blink feature core that produces method-suffixed metrics and respects modality support
- update per-blink feature helpers and BlinkProperties to delegate to the core, expose blink_bounds, and NaN-out *_zero fields for EAR
- compute metrics after segmentation and refresh kinematic/morphology tests for the new key space

## Testing
- pytest test/blink_features/kinematics test/blink_features/morphology
- pytest test/blinker_migration
- ruff check .

------
https://chatgpt.com/codex/tasks/task_e_68ca2d17585083259d648a9954233ba3