### PR TITLE
Refactor shared epoch feature utilities

### DIFF
--- a/pyblinker/blink_features/kinematics/kinematic_features.py
+++ b/pyblinker/blink_features/kinematics/kinematic_features.py
@@ -12,23 +12,13 @@ import pandas as pd
 
 from .per_blink import compute_segment_kinematics
 from ..energy.helpers import extract_blink_windows, segment_to_samples, _safe_stats
+from ...utils.epoch_utils import build_metric_stat_columns, resolve_channels
 
 logger = get_logger(__name__)
 
 # Derive metric and statistic names from helper functions to avoid hardcoding
 _METRICS = tuple(compute_segment_kinematics(np.zeros(3), 1.0).keys())
 _STATS = tuple(_safe_stats([]).keys())
-
-
-def _make_columns(ch_names: Sequence[str]) -> List[str]:
-    """Generate ordered column names for all metrics and statistics."""
-
-    columns: List[str] = []
-    for ch in ch_names:
-        for metric in _METRICS:
-            for stat in _STATS:
-                columns.append(f"{metric}_{stat}_{ch}")
-    return columns
 
 
 def compute_kinematic_features(
@@ -57,22 +47,13 @@ def compute_kinematic_features(
     are ``NaN``.
     """
 
-    if picks is None:
-        ch_names = epochs.ch_names
-    elif isinstance(picks, str):
-        ch_names = [picks]
-    else:
-        ch_names = list(picks)
-
-    missing = [ch for ch in ch_names if ch not in epochs.ch_names]
-    if missing:
-        raise ValueError(f"Channels not found: {missing}")
+    ch_names = resolve_channels(epochs, picks)
 
     sfreq = float(epochs.info["sfreq"])
     n_epochs = len(epochs)
     n_times = epochs.get_data(picks=[ch_names[0]]).shape[-1] if n_epochs else 0
 
-    columns = _make_columns(ch_names)
+    columns = build_metric_stat_columns(ch_names, _METRICS, _STATS)
     index = (
         epochs.metadata.index
         if isinstance(epochs.metadata, pd.DataFrame)

--- a/pyblinker/blink_features/morphology/epoch_features.py
+++ b/pyblinker/blink_features/morphology/epoch_features.py
@@ -10,6 +10,7 @@ import pandas as pd
 
 from .per_blink import compute_blink_waveform_metrics
 from ..energy.helpers import extract_blink_windows, segment_to_samples, _safe_stats
+from ...utils.epoch_utils import build_metric_stat_columns, resolve_channels
 from ...utils.modality import infer_modality
 
 logger = get_logger(__name__)
@@ -21,14 +22,15 @@ _METRICS = _BASE_METRICS + ("duration",)
 _STATS = tuple(_safe_stats([]).keys())
 
 
-def _make_columns(ch_names: Sequence[str]) -> List[str]:
-    """Generate ordered column names for the output DataFrame."""
-    columns: List[str] = []
-    for ch in ch_names:
-        for metric in _METRICS:
-            for stat in _STATS:
-                columns.append(f"{metric}_{stat}_{ch}")
-    return columns
+def _default_morphology_channels(epochs: mne.Epochs) -> List[str]:
+    """Select default EAR/EOG channels when ``picks`` are unspecified."""
+
+    ch_names = [
+        ch for ch in epochs.ch_names if "EOG" in ch.upper() or "EAR" in ch.upper()
+    ]
+    if not ch_names:
+        raise ValueError("No default EAR/EOG channels found")
+    return ch_names
 
 
 def compute_epoch_morphology_features(
@@ -63,29 +65,14 @@ def compute_epoch_morphology_features(
     if epochs.metadata is None:
         raise ValueError("epochs.metadata must be provided")
 
-    if picks is None:
-        ch_names = [
-            ch
-            for ch in epochs.ch_names
-            if "EOG" in ch.upper() or "EAR" in ch.upper()
-        ]
-        if not ch_names:
-            raise ValueError("No default EAR/EOG channels found")
-    elif isinstance(picks, str):
-        ch_names = [picks]
-    else:
-        ch_names = list(picks)
-
-    missing = [ch for ch in ch_names if ch not in epochs.ch_names]
-    if missing:
-        raise ValueError(f"Channels not found: {missing}")
+    ch_names = resolve_channels(epochs, picks, default=_default_morphology_channels)
 
     data = epochs.get_data(picks=ch_names)
     sfreq = float(epochs.info["sfreq"])
     n_epochs, n_ch, n_times = data.shape
     index = epochs.metadata.index
 
-    columns = _make_columns(ch_names)
+    columns = build_metric_stat_columns(ch_names, _METRICS, _STATS)
     if n_epochs == 0:
         return pd.DataFrame(index=index, columns=columns, dtype=float)
 

--- a/pyblinker/utils/epoch_utils.py
+++ b/pyblinker/utils/epoch_utils.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import List, Optional, Tuple
+from typing import Callable, List, Optional, Sequence, Tuple
 
 import mne
 import numpy as np
@@ -11,8 +11,44 @@ import pandas as pd
 from tqdm import tqdm
 
 from pyblinker.logging import get_logger
+from .channel_utils import normalize_picks, require_channels
 
 logger = get_logger(__name__)
+
+
+ChannelSelector = Callable[[mne.Epochs], Sequence[str]]
+
+
+def resolve_channels(
+    epochs: mne.Epochs,
+    picks: str | Sequence[str] | None,
+    *,
+    default: ChannelSelector | None = None,
+) -> List[str]:
+    """Resolve and validate channel names for feature extraction."""
+
+    logger.debug("Resolving channel picks: %s", picks)
+    if picks is None:
+        ch_names = (
+            list(epochs.ch_names) if default is None else list(default(epochs))
+        )
+    else:
+        ch_names = normalize_picks(picks)
+    require_channels(epochs, ch_names)
+    return ch_names
+
+
+def build_metric_stat_columns(
+    ch_names: Sequence[str], metrics: Sequence[str], stats: Sequence[str]
+) -> List[str]:
+    """Construct column names for metric/statistic combinations per channel."""
+
+    return [
+        f"{metric}_{stat}_{ch}"
+        for ch in ch_names
+        for metric in metrics
+        for stat in stats
+    ]
 
 
 def slice_raw_to_segments(
@@ -177,6 +213,8 @@ def slice_into_mini_raws(
 
 
 __all__ = [
+    "resolve_channels",
+    "build_metric_stat_columns",
     "slice_raw_to_segments",
     "slice_raw_into_mne_epochs",
     "slice_raw_into_epochs",


### PR DESCRIPTION
## Summary
- relocate the shared epoch feature helper functions into the existing `pyblinker.utils.epoch_utils` module alongside the channel utilities
- update morphology and kinematic epoch feature extraction to import the shared helpers from the utils package

## Testing
- ruff check .

------
https://chatgpt.com/codex/tasks/task_e_68cff46f900c832593147adddb358b20