### PR TITLE
Move blink maximum helper into statistics utils

### DIFF
--- a/pyblinker/blinker/fit_blink.py
+++ b/pyblinker/blinker/fit_blink.py
@@ -2,7 +2,6 @@ import logging
 import warnings
 from pyblinker.logging import get_logger
 
-import numpy as np
 import pandas as pd
 
 from .zero_crossing import (
@@ -12,6 +11,7 @@ from .zero_crossing import (
 )
 from .base_left_right import create_left_right_base
 from ..fitutils.line_intersection import lines_intersection
+from ..utils.statistics_utils import get_max_blink
 
 
 logger = get_logger(__name__)
@@ -60,33 +60,6 @@ class FitBlinks:
             "right_x_intercept",
         ]
 
-    def get_max_blink(self, start_idx, end_idx):
-        """Return the maximum value and its index within ``start_idx`` and ``end_idx``.
-
-        Parameters
-        ----------
-        start_idx : int or float
-            Starting sample index of the blink window.
-        end_idx : int or float
-            Ending sample index of the blink window.
-
-        Returns
-        -------
-        tuple[float, int]
-            ``(max_value, frame_index_at_max)`` within the specified range.
-        """
-
-        start_idx = int(start_idx)
-        end_idx = int(end_idx)
-
-        blink_range = np.arange(start_idx, end_idx + 1, dtype=int)
-        blink_frame = self.candidate_signal[start_idx : end_idx + 1]
-        # One-pass for max value and index
-        max_idx = np.argmax(blink_frame)
-        max_val = blink_frame[max_idx]
-        max_fr = blink_range[max_idx]
-        return max_val, max_fr
-
     def dprocess_segment_raw(self, *, run_fit: bool = False) -> None:
         """Process blink metadata for a raw segment.
 
@@ -113,14 +86,18 @@ class FitBlinks:
 
         # Compute the maximum value within each blink interval
         # self.df[["max_value", "max_blink"]] = self.df.apply(
-        #     lambda row: self.get_max_blink(row["start_blink"], row["end_blink"]),
+        #     lambda row: get_max_blink(
+        #         self.candidate_signal, row["start_blink"], row["end_blink"]
+        #     ),
         #     axis=1,
         #     result_type="expand",
         # )
         if not {"max_value", "max_blink"}.issubset(self.df.columns):
             # Compute the maximum value within each blink interval
             self.df[["max_value", "max_blink"]] = self.df.apply(
-                lambda row: self.get_max_blink(row["start_blink"], row["end_blink"]),
+                lambda row: get_max_blink(
+                    self.candidate_signal, row["start_blink"], row["end_blink"]
+                ),
                 axis=1,
                 result_type="expand",
             )
@@ -155,7 +132,9 @@ class FitBlinks:
 
         # Find the max_frame index and max_value at that max_frame index
         self.df[["max_value", "max_blink"]] = self.df.apply(
-            lambda row: self.get_max_blink(row["start_blink"], row["end_blink"]),
+            lambda row: get_max_blink(
+                self.candidate_signal, row["start_blink"], row["end_blink"]
+            ),
             axis=1,
             result_type="expand",
         )

--- a/pyblinker/utils/__init__.py
+++ b/pyblinker/utils/__init__.py
@@ -29,6 +29,7 @@ from .statistics_utils import (
     calculate_within_range,
     get_blink_statistic,
     get_good_blink_mask,
+    get_max_blink,
 )
 from .velocity_utils import average_velocity
 
@@ -56,6 +57,7 @@ __all__ = [
     "calculate_good_ratio",
     "get_blink_statistic",
     "get_good_blink_mask",
+    "get_max_blink",
     "average_velocity",
     "infer_modality",
 ]

--- a/pyblinker/utils/statistics_utils.py
+++ b/pyblinker/utils/statistics_utils.py
@@ -11,6 +11,38 @@ from pyblinker.blinker.default_setting import SCALING_FACTOR
 from pyblinker.fitutils import mad
 
 
+def get_max_blink(
+    candidate_signal: np.ndarray,
+    start_idx: int | float,
+    end_idx: int | float,
+) -> tuple[float, int]:
+    """Return the maximum value and index within ``start_idx`` and ``end_idx``.
+
+    Parameters
+    ----------
+    candidate_signal
+        The signal values that contain the blink of interest.
+    start_idx
+        Starting sample index of the blink window (inclusive).
+    end_idx
+        Ending sample index of the blink window (inclusive).
+
+    Returns
+    -------
+    tuple[float, int]
+        ``(max_value, frame_index_at_max)`` within the specified range.
+    """
+
+    start = int(start_idx)
+    end = int(end_idx)
+
+    signal = np.asarray(candidate_signal)
+    blink_frame = signal[start : end + 1]
+    max_idx = int(np.argmax(blink_frame))
+    max_val = float(blink_frame[max_idx])
+    return max_val, start + max_idx
+
+
 def calculate_within_range(
     all_values: np.ndarray, best_median: float, best_robust_std: float
 ) -> int:
@@ -141,6 +173,7 @@ def get_good_blink_mask(
 
 
 __all__ = [
+    "get_max_blink",
     "calculate_within_range",
     "calculate_good_ratio",
     "get_blink_statistic",


### PR DESCRIPTION
## Summary
- move the blink maximum extraction helper into `statistics_utils` and export it through the utils package
- update `FitBlinks` to consume the shared utility instead of its instance method

## Testing
- pytest test/blinker_migration/test_step2b_getGoodBlinkMask.py

------
https://chatgpt.com/codex/tasks/task_e_68d0b1af7ba48325b6fdc8ce3327a0df