### PR TITLE
Replace warnings with logging and reduce noisy info logs

### DIFF
--- a/pyblinker/blink_features/energy/helpers.py
+++ b/pyblinker/blink_features/energy/helpers.py
@@ -37,13 +37,13 @@ def segment_to_samples(onset_s: float, duration_s: float, sfreq: float, n_times:
         Slice object representing the samples belonging to the blink. The
         slice is clamped to the valid range ``[0, n_times)``.
     """
-    logger.info("Entering segment_to_samples")
+    logger.debug("Entering segment_to_samples")
     start = int(round(onset_s * sfreq))
     stop = start + int(round(duration_s * sfreq))
     start = max(start, 0)
     stop = min(stop, n_times)
     logger.debug("Blink window samples: start=%d stop=%d", start, stop)
-    logger.info("Exiting segment_to_samples")
+    logger.debug("Exiting segment_to_samples")
     return slice(start, stop)
 
 

--- a/pyblinker/blink_features/energy/segment_features.py
+++ b/pyblinker/blink_features/energy/segment_features.py
@@ -28,7 +28,7 @@ def compute_time_domain_features(signal: np.ndarray, sfreq: float) -> Dict[str, 
         Dictionary with energy, Teager energy, line length and velocity integral.
     """
     signal_arr = np.asarray(signal, dtype=float)
-    logger.info(
+    logger.debug(
         "Computing time-domain features for segment of length %d", signal_arr.size
     )
     metrics = compute_energy_metrics(signal_arr, sfreq)

--- a/pyblinker/blink_features/frequency_domain/aggregate.py
+++ b/pyblinker/blink_features/frequency_domain/aggregate.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 from pyblinker.logging import get_logger
 
 from typing import Dict, List, Sequence
-import warnings
 
 import mne
 import numpy as np
@@ -56,11 +55,10 @@ class FrequencyDomainBlinkFeatureExtractor:
             DataFrame indexed like ``epochs`` with columns ``ep`` and
             ``wavelet_energy_d1`` .. ``wavelet_energy_d4``.
 
-        Warns
+        Notes
         -----
-        UserWarning
-            If the sampling frequency is below 30 Hz, features may be
-            unreliable.
+        A warning is logged when the sampling frequency is below 30 Hz
+        because wavelet features become unreliable at low rates.
         """
 
         if self.epochs is None:
@@ -68,8 +66,9 @@ class FrequencyDomainBlinkFeatureExtractor:
 
         sfreq = self._sampling_frequency()
         if sfreq < 30:
-            warnings.warn(
-                "Frequency-domain features may be unreliable below 30 Hz", UserWarning
+            logger.warning(
+                "Frequency-domain features may be unreliable below 30 Hz",
+                extra={"sfreq": sfreq},
             )
 
         if picks is None:

--- a/pyblinker/blink_features/frequency_domain/features.py
+++ b/pyblinker/blink_features/frequency_domain/features.py
@@ -43,11 +43,14 @@ def _compute_wavelet_energies(
         cannot be computed due to segment length or Nyquist constraints the
         corresponding entry is ``NaN``.
     """
-    logger.info("Computing wavelet energies for segment of length %d", segment.size)
+    logger.debug("Computing wavelet energies for segment of length %d", segment.size)
     logger.debug("Sampling frequency: %.2f Hz", sfreq)
 
     if segment.size == 0:
-        logger.info("Segment empty; returning NaNs")
+        logger.warning(
+            "Wavelet energy computation received empty segment; returning NaNs",
+            extra={"segment_length": int(segment.size)},
+        )
         return [float("nan")] * max_level
 
     max_level_available = min(pywt.dwt_max_level(segment.size, "db4"), max_level)
@@ -68,5 +71,5 @@ def _compute_wavelet_energies(
         coeff = coeffs[level]
         energies.append(float(np.sum(coeff**2)))
 
-    logger.info("Computed %d wavelet energy values", len(energies))
+    logger.debug("Computed %d wavelet energy values", len(energies))
     return energies

--- a/pyblinker/blink_features/frequency_domain/segment_features.py
+++ b/pyblinker/blink_features/frequency_domain/segment_features.py
@@ -33,7 +33,7 @@ def compute_frequency_domain_features(
         corresponding energy values. Levels that cannot be computed are ``NaN``.
     """
 
-    logger.info(
+    logger.debug(
         "Computing segment frequency-domain features (n=%d sfreq=%.2f)",
         len(segment_signal),
         sfreq,

--- a/pyblinker/blinker/blink_epoch_mapper.py
+++ b/pyblinker/blinker/blink_epoch_mapper.py
@@ -198,7 +198,7 @@ def map_blinks_to_epochs(
     progress_bar: bool = True,
 ) -> pd.DataFrame:
     """Map blink onsets back to each epoch."""
-    logger.info("Entering map_blinks_to_epochs")
+    logger.debug("Entering map_blinks_to_epochs")
     sfreq = epochs.info["sfreq"]
     ep_starts, ep_ends = _epoch_boundaries_in_samples(epochs)
 
@@ -232,7 +232,7 @@ def map_blinks_to_epochs(
         "blink_durations": durations,
     }, index=epochs.selection)
 
-    logger.info("Leaving map_blinks_to_epochs")
+    logger.debug("Leaving map_blinks_to_epochs")
     return meta
 
 
@@ -249,14 +249,14 @@ def add_blink_counts(epochs: mne.Epochs) -> mne.Epochs:
     mne.Epochs
         The same object with a new ``n_blinks`` column in ``metadata``.
     """
-    logger.info("Adding blink counts to metadata")
+    logger.debug("Adding blink counts to metadata")
     if epochs.metadata is None:
         raise ValueError("Epochs.metadata is missing blink information")
 
     meta = epochs.metadata.copy()
     meta["n_blinks"] = meta["blink_onsets"].apply(len)
     epochs.metadata = meta
-    logger.info("Blink counts added")
+    logger.debug("Blink counts added")
     return epochs
 
 
@@ -292,7 +292,7 @@ def find_blinks_epoch(
         The input epochs updated with blink metadata attached to
         ``epochs.metadata``.
     """
-    logger.info("Entering find_blinks_epoch")
+    logger.debug("Entering find_blinks_epoch")
 
     if ch_name is None:
         ch_idx = 0
@@ -333,6 +333,6 @@ def find_blinks_epoch(
     add_blink_counts(epochs)
 
     logger.info("Assigned blink metadata to epochs")
-    logger.info("Leaving find_blinks_epoch")
+    logger.debug("Leaving find_blinks_epoch")
     return epochs
 

--- a/pyblinker/blinker/fit_blink.py
+++ b/pyblinker/blinker/fit_blink.py
@@ -1,5 +1,3 @@
-import logging
-import warnings
 from pyblinker.logging import get_logger
 
 import pandas as pd
@@ -103,10 +101,10 @@ class FitBlinks:
 
 
         if run_fit:
-            msg = "Running fit() may drop blinks due to NaNs in fit range"
-            logger.warning(msg)
-            if logger.isEnabledFor(logging.DEBUG):
-                warnings.warn(msg, RuntimeWarning)
+            logger.warning(
+                "Running fit() may drop blinks due to NaNs in fit range",
+                extra={"run_fit": run_fit},
+            )
             self.fit()
         else:
             # Compute baseline information required by downstream features

--- a/pyblinker/blinker/fit_range.py
+++ b/pyblinker/blinker/fit_range.py
@@ -8,9 +8,12 @@ dedicated, easier to maintain home.
 
 from __future__ import annotations
 
-import warnings
+from pyblinker.logging import get_logger
 
 import numpy as np
+
+logger = get_logger(__name__)
+
 
 def get_left_range(left_zero, max_blink, candidate_signal, blink_top, blink_bottom):
     """Identify the left blink range using the provided thresholds."""
@@ -125,7 +128,10 @@ def compute_fit_range(
 
     if top_bottom is None:
         # Return minimal information
-        warnings.warn("To modify this so that all function return the top_bottom point")
+        logger.warning(
+            "compute_fit_range called without top_bottom flag; returning minimal output",
+            extra={"top_bottom": top_bottom},
+        )
         return x_left, x_right, left_range, right_range
 
     # Return extended info including top/bottom points

--- a/pyblinker/blinker/zero_crossing.py
+++ b/pyblinker/blinker/zero_crossing.py
@@ -1,4 +1,3 @@
-import warnings
 from pyblinker.logging import get_logger
 
 import numpy as np
@@ -87,8 +86,10 @@ def left_right_zero_crossing(
         try:
             extreme_outer = np.arange(m_frame, candidate_signal.shape[0], dtype=int)
         except TypeError:
-            print("Error")
-            # If this except triggers, raise or handle accordingly
+            logger.exception(
+                "Failed to extend search range to signal boundary; returning NaN",
+                extra={"max_blink": m_frame},
+            )
             return left_zero, np.nan
 
         s_ind_right_zero_ex = np.flatnonzero(candidate_signal[extreme_outer] < 0)
@@ -146,8 +147,9 @@ def max_pos_vel_frame(blink_velocity, max_blink, left_zero, right_zero):
         max_neg_vel_idx = np.argmin(blink_velocity[down_stroke])
         max_neg_vel_frame = down_stroke[max_neg_vel_idx]
     else:
-        warnings.warn(
-            "Force nan but require further investigation why happen like this"
+        logger.warning(
+            "Down-stroke segment empty; forcing NaN for max negative velocity",
+            extra={"down_stroke_size": int(down_stroke.size)},
         )
         max_neg_vel_frame = np.nan
 

--- a/pyblinker/fitutils/forking.py
+++ b/pyblinker/fitutils/forking.py
@@ -262,7 +262,7 @@ def polyval(p, x, S=None, mu=None):
     delta : ndarray or None
         Prediction error estimates at x.
     """
-    logger.info("Entering polyval")
+    logger.debug("Entering polyval")
 
     # Ensure p is a vector or empty
     if not (np.ndim(p) == 1 or len(p) == 0):
@@ -294,7 +294,7 @@ def polyval(p, x, S=None, mu=None):
         # Check if R is singular
         if np.linalg.det(R) == 0:
             logger.warning("Singular matrix R. Skipping delta calculation.")
-            logger.info("Exiting polyval")
+            logger.debug("Exiting polyval")
             return y, None
 
         # Construct Vandermonde matrix for x
@@ -310,7 +310,7 @@ def polyval(p, x, S=None, mu=None):
             E = E_T.T
         except np.linalg.LinAlgError as e:
             logger.exception("Error solving triangular system: %s", e)
-            logger.info("Exiting polyval")
+            logger.debug("Exiting polyval")
             return y, None
 
         e = np.sqrt(1 + np.sum(E ** 2, axis=1))
@@ -322,7 +322,7 @@ def polyval(p, x, S=None, mu=None):
 
         delta = delta.reshape(x.shape)
 
-    logger.info("Exiting polyval")
+    logger.debug("Exiting polyval")
     return y, delta
 
 

--- a/pyblinker/pipeline_steps.py
+++ b/pyblinker/pipeline_steps.py
@@ -22,7 +22,7 @@ logger = get_logger(__name__)
 
 def process_channel_data(detector, channel: str, verbose: bool = True) -> None:
     """Process blink data for a single channel using the legacy six-step pipeline."""
-    logger.info(f"Processing channel: {channel}")
+    logger.debug("Processing channel: %s", channel)
 
     # STEP 1: Get blink positions
     df = get_blink_position(
@@ -32,7 +32,7 @@ def process_channel_data(detector, channel: str, verbose: bool = True) -> None:
     )
 
     if df.empty and verbose:
-        logger.warning(f"No blinks detected in channel: {channel}")
+        logger.warning("No blinks detected in channel: %s", channel)
 
     # STEP 2: Fit blinks
     fitblinks = FitBlinks(
@@ -80,7 +80,7 @@ def process_channel_data(detector, channel: str, verbose: bool = True) -> None:
 
 def process_all_channels(detector) -> None:
     """Process all channels available in the raw data."""
-    logger.info(f"Processing {len(detector.channel_list)} channels.")
+    logger.info("Processing %d channels.", len(detector.channel_list))
     for channel in tqdm(
         detector.channel_list, desc="Processing Channels", unit="channel", colour="BLACK"
     ):
@@ -114,7 +114,9 @@ def get_blink(detector):
     process_all_channels(detector)
 
     ch_selected = select_representative_channel(detector)
-    logger.info(f"Selected representative channel: {ch_selected.loc[0, 'ch']}")
+    logger.info(
+        "Selected representative channel: %s", ch_selected.loc[0, "ch"]
+    )
 
     ch, data, df = get_representative_blink_data(detector, ch_selected)
     annot = detector.create_annotations(df)
@@ -122,7 +124,10 @@ def get_blink(detector):
     fig_data = detector.generate_viz(data, df) if detector.viz_data else []
     n_good_blinks = ch_selected.loc[0, "number_good_blinks"]
 
-    logger.info(f"Blink detection completed. {n_good_blinks} good blinks detected.")
+    logger.info(
+        "Blink detection completed. %d good blinks detected.",
+        n_good_blinks,
+    )
 
     return annot, ch, n_good_blinks, df, fig_data, ch_selected
 

--- a/pyblinker/utils/annotation_utils.py
+++ b/pyblinker/utils/annotation_utils.py
@@ -42,7 +42,7 @@ def create_annotation(
         If required columns are missing or ``sfreq`` is non-positive.
     """
 
-    logger.info("Entering create_annotation")
+    logger.debug("Entering create_annotation")
     if not isinstance(sblink, pd.DataFrame):
         raise TypeError("sblink must be a pandas.DataFrame")
 
@@ -71,7 +71,7 @@ def create_annotation(
         duration=duration,
         description=list(descriptions),
     )
-    logger.info("Exiting create_annotation")
+    logger.debug("Exiting create_annotation")
     return annot
 
 

--- a/pyblinker/utils/channel_utils.py
+++ b/pyblinker/utils/channel_utils.py
@@ -55,7 +55,7 @@ def require_channels(
     ValueError
         If any channel in ``picks`` is missing from ``data``.
     """
-    logger.info("Validating channel picks: %s", picks)
+    logger.debug("Validating channel picks: %s", picks)
     if isinstance(data, (mne.Epochs, BaseRaw)):
         ch_names = data.info["ch_names"]
     else:

--- a/pyblinker/utils/epoch_utils.py
+++ b/pyblinker/utils/epoch_utils.py
@@ -81,7 +81,7 @@ def slice_raw_into_mne_epochs(
 ) -> mne.Epochs:
     """Convert a continuous recording into equally spaced MNE epochs."""
 
-    logger.info("Entering slice_raw_into_mne_epochs")
+    logger.debug("Entering slice_raw_into_mne_epochs")
     events = mne.make_fixed_length_events(raw, duration=epoch_len)
     sfreq = raw.info["sfreq"]
     epochs = mne.Epochs(
@@ -122,7 +122,7 @@ def slice_raw_into_mne_epochs(
                     metadata.at[idx, "blink_duration"] = rel_durations.tolist()
     epochs.metadata = metadata
     logger.debug("Epoch metadata head: %s", metadata.head())
-    logger.info("Exiting slice_raw_into_mne_epochs")
+    logger.debug("Exiting slice_raw_into_mne_epochs")
     return epochs
 
 
@@ -194,7 +194,7 @@ def slice_into_mini_raws(
 ) -> Tuple[List[mne.io.BaseRaw], pd.DataFrame, List[Tuple[int, int]], Optional["mne.Report"]]:
     """Slice a raw recording into epochs with optional saving and reporting."""
 
-    logger.info("Entering slice_into_mini_raws")
+    logger.debug("Entering slice_into_mini_raws")
     segments, df, boundary_pairs, times = slice_raw_into_epochs(
         raw, epoch_len=epoch_len, blink_label=blink_label, progress_bar=progress_bar
     )
@@ -208,7 +208,7 @@ def slice_into_mini_raws(
 
             rep = generate_epoch_report(segments, times, verbose=False)
             rep.save(out_dir / "epoch_report.html", overwrite=overwrite, open_browser=False)
-    logger.info("Exiting slice_into_mini_raws")
+    logger.debug("Exiting slice_into_mini_raws")
     return segments, df, boundary_pairs, rep
 
 

--- a/pyblinker/utils/metadata_utils.py
+++ b/pyblinker/utils/metadata_utils.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
 def onset_entry_to_blinks(onset: Any) -> List[Dict[str, float]]:
     """Convert a ``blink_onset`` metadata entry into blink dictionaries."""
 
-    logger.info("Entering onset_entry_to_blinks")
+    logger.debug("Entering onset_entry_to_blinks")
     if isinstance(onset, list):
         blinks = [{"onset": float(o)} for o in onset]
     elif onset is None or pd.isna(onset):
@@ -30,14 +30,14 @@ def onset_entry_to_blinks(onset: Any) -> List[Dict[str, float]]:
     else:
         blinks = [{"onset": float(onset)}]
     logger.debug("Converted %s to %d blink entries", onset, len(blinks))
-    logger.info("Exiting onset_entry_to_blinks")
+    logger.debug("Exiting onset_entry_to_blinks")
     return blinks
 
 
 def attach_blink_metadata(epochs: "mne.Epochs", blink_df: pd.DataFrame) -> pd.DataFrame:
     """Aggregate per-blink properties and merge them into epoch metadata."""
 
-    logger.info("Entering attach_blink_metadata")
+    logger.debug("Entering attach_blink_metadata")
 
     sfreq = float(epochs.info["sfreq"])
     selection_map = {orig: new for new, orig in enumerate(epochs.selection)}
@@ -83,7 +83,7 @@ def attach_blink_metadata(epochs: "mne.Epochs", blink_df: pd.DataFrame) -> pd.Da
     epochs.metadata = merged
     epochs.metadata.reset_index(drop=True, inplace=True)
 
-    logger.info("Exiting attach_blink_metadata")
+    logger.debug("Exiting attach_blink_metadata")
     return df.drop(columns=["epoch_index"])
 
 
@@ -96,7 +96,7 @@ def sample_windows_from_metadata(
 ) -> List[slice]:
     """Convert blink onset/duration metadata to sample windows."""
 
-    logger.info("Entering sample_windows_from_metadata")
+    logger.debug("Entering sample_windows_from_metadata")
     windows = extract_blink_windows(metadata, channel, epoch_index)
     sample_windows: List[slice] = []
     for onset_s, duration_s in windows:
@@ -104,7 +104,7 @@ def sample_windows_from_metadata(
         if sl.stop - sl.start > 1:
             sample_windows.append(sl)
     logger.debug("Found %d sample windows", len(sample_windows))
-    logger.info("Exiting sample_windows_from_metadata")
+    logger.debug("Exiting sample_windows_from_metadata")
     return sample_windows
 
 
@@ -116,7 +116,7 @@ def extract_blink_windows(
     """Extract blink onset/duration pairs for a single epoch."""
 
     channel_label = channel if channel is not None else "generic"
-    logger.info(
+    logger.debug(
         "Entering extract_blink_windows for channel %s (epoch %d)",
         channel_label,
         epoch_index,
@@ -152,7 +152,7 @@ def extract_blink_windows(
                 channel_label,
             )
             windows: List[Tuple[float, float]] = []
-            logger.info("Exiting extract_blink_windows")
+            logger.debug("Exiting extract_blink_windows")
             return windows
     else:
         generic_keys = ("blink_onset", "blink_duration")
@@ -171,7 +171,7 @@ def extract_blink_windows(
                 channel_label,
             )
             windows = []
-            logger.info("Exiting extract_blink_windows")
+            logger.debug("Exiting extract_blink_windows")
             return windows
 
     onsets_list = ensure_list(onsets)
@@ -184,7 +184,7 @@ def extract_blink_windows(
         windows.append((float(onset), float(duration)))
 
     logger.debug("Extracted %d blink windows", len(windows))
-    logger.info("Exiting extract_blink_windows")
+    logger.debug("Exiting extract_blink_windows")
     return windows
 
 

--- a/pyblinker/utils/refinement_utils.py
+++ b/pyblinker/utils/refinement_utils.py
@@ -234,7 +234,7 @@ def slice_raw_into_mne_epochs_refine_annot(
     epochs.metadata = metadata
 
     logger.debug("Epoch metadata head: %s", metadata.head())
-    logger.info("Exiting slice_raw_into_mne_epochs_refine_annot")
+    logger.debug("Exiting slice_raw_into_mne_epochs_refine_annot")
     return epochs
 
 

--- a/test/blink_features/frequency_domain/test_frequency_domain_blink_features.py
+++ b/test/blink_features/frequency_domain/test_frequency_domain_blink_features.py
@@ -13,11 +13,7 @@ from pyblinker.blink_features.frequency_domain import (
 )
 from pyblinker.utils.refinement_utils import slice_raw_into_mne_epochs_refine_annot
 
-from ..utils.helpers import (
-    assert_df_has_columns,
-    assert_numeric_or_nan,
-    with_userwarning,
-)
+from ..utils.helpers import assert_df_has_columns, assert_numeric_or_nan
 
 
 PROJECT_ROOT = Path(__file__).resolve().parents[3]
@@ -58,12 +54,19 @@ class TestFrequencyDomainBlinkFeatures(unittest.TestCase):
             extractor.compute()
 
     def test_low_sampling_frequency_warning(self) -> None:
-        """Warn and drop Nyquist-touching levels when fs < 30 Hz."""
+        """Log a warning and drop Nyquist-touching levels when fs < 30 Hz."""
         epochs = self.epochs.copy().resample(20.0, npad="auto")
-        with with_userwarning(self):
+        with self.assertLogs("pyblinker", level="WARNING") as cm:
             df = aggregate_frequency_domain_features(
                 epochs, picks="EAR-avg_ear", progress_bar=False
             )
+        self.assertTrue(
+            any(
+                "Frequency-domain features may be unreliable below 30 Hz" in message
+                for message in cm.output
+            ),
+            msg="Expected warning log missing",
+        )
         self.assertTrue(df["wavelet_energy_d1"].isna().all())
         assert_df_has_columns(
             self, df, ["ep"] + [f"wavelet_energy_d{i}" for i in range(2, 5)]

--- a/test/blink_features/full_epoch_feature_pipeline/test_segment_raw_feature_pipeline.py
+++ b/test/blink_features/full_epoch_feature_pipeline/test_segment_raw_feature_pipeline.py
@@ -79,21 +79,22 @@ class TestSegmentRawFeaturePipeline(unittest.TestCase):
         df_energy = pd.DataFrame(energy_rows)
 
         if run_fit:
-            fit_logger = logging.getLogger("pyblinker.blinker.fit_blink")
-            prev_level = fit_logger.level
-            fit_logger.setLevel(logging.DEBUG)
-            try:
-                with self.assertWarns(RuntimeWarning):
-                    blink_props = compute_segment_blink_properties(
-                        self.segments,
-                        self.params,
-                        blink_df=self.blink_df,
-                        channel="EEG-E8",
-                        run_fit=run_fit,
-                        progress_bar=False,
-                    )
-            finally:
-                fit_logger.setLevel(prev_level)
+            with self.assertLogs("pyblinker.blinker.fit_blink", level="WARNING") as cm:
+                blink_props = compute_segment_blink_properties(
+                    self.segments,
+                    self.params,
+                    blink_df=self.blink_df,
+                    channel="EEG-E8",
+                    run_fit=run_fit,
+                    progress_bar=False,
+                )
+            self.assertTrue(
+                any(
+                    "Running fit() may drop blinks due to NaNs in fit range" in message
+                    for message in cm.output
+                ),
+                msg="Expected fit warning log missing",
+            )
         else:
             blink_props = compute_segment_blink_properties(
                 self.segments,

--- a/test/blink_features/utils/helpers.py
+++ b/test/blink_features/utils/helpers.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 from typing import Sequence, Iterable, List
 
-from contextlib import contextmanager
 import numpy as np
 import pandas as pd
 
@@ -16,13 +15,6 @@ def assert_numeric_or_nan(testcase, values: Iterable[float]) -> None:
     arr = np.asarray(list(values), dtype=float)
     condition = np.isfinite(arr) | np.isnan(arr)
     testcase.assertTrue(condition.all(), msg="Values contain non-numeric entries")
-
-
-@contextmanager
-def with_userwarning(testcase):
-    """Context manager asserting a :class:`UserWarning` is raised."""
-    with testcase.assertWarns(UserWarning):
-        yield
 
 
 def assert_df_has_columns(testcase, df: pd.DataFrame, columns: Sequence[str]) -> None:


### PR DESCRIPTION
## Summary
- replace direct uses of `warnings.warn` with package loggers across blink feature helpers, including richer context when emitting warnings
- downgrade per-segment/channel INFO logs to DEBUG in frequently invoked utilities to minimize noise while keeping high-level INFO messages
- update frequency-domain and pipeline tests to assert on logged warnings rather than Python warning emissions

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d107ef24908325b7d1a1e7affaf7f9